### PR TITLE
[TASK-62] feat: 작가 프로필 카드 구현

### DIFF
--- a/src/apis/follow/deleteFollow.ts
+++ b/src/apis/follow/deleteFollow.ts
@@ -1,0 +1,31 @@
+import { isAxiosError } from 'axios';
+
+import { USER } from '@/constants/API';
+import {
+  COMMON_ERROR_MESSAGE,
+  FOLLOW_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { authorizedClient } from '..';
+
+const deleteFollow = async (userId: number) => {
+  try {
+    const response = await authorizedClient.delete(USER.follow, {
+      data: { userId },
+    });
+
+    return response.status === 204;
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) console.error(FOLLOW_ERROR_MESSAGE[code]);
+      else console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+    } else {
+      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+
+    return false;
+  }
+};
+
+export default deleteFollow;

--- a/src/apis/follow/postFollow.ts
+++ b/src/apis/follow/postFollow.ts
@@ -1,0 +1,28 @@
+import { USER } from '@/constants/API';
+import {
+  COMMON_ERROR_MESSAGE,
+  FOLLOW_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { isAxiosError } from 'axios';
+import { authorizedClient } from '..';
+
+const postFollow = async (userId: number) => {
+  try {
+    const response = await authorizedClient.post<null>(USER.follow, { userId });
+
+    return response.status === 204;
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) console.error(FOLLOW_ERROR_MESSAGE[code]);
+      else console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+    } else {
+      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+
+    return false;
+  }
+};
+
+export default postFollow;

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -8,4 +8,12 @@ const defaultClient = axios.create({
   },
 });
 
+export const authorizedClient = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_MOCK_URL,
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  },
+});
+
 export default defaultClient;

--- a/src/components/Button/FollowButton.tsx
+++ b/src/components/Button/FollowButton.tsx
@@ -4,22 +4,35 @@ import { useState } from 'react';
 
 import { FollowButtonProps } from '@/types/buttons/FollowButtonProps';
 
+import deleteFollow from '@/apis/follow/deleteFollow';
+import postFollow from '@/apis/follow/postFollow';
 import Icon from '../Icon/Icon';
 
 const FollowButton = ({
   textSize = 'button-s',
   initFollowState = false,
-  onClick,
   ariaLabel,
+  followUserId,
 }: FollowButtonProps) => {
   const [isFollowing, setIsFollowing] = useState(initFollowState);
+  const [isLoading, setIsLoading] = useState(false);
 
-  const toggleFollow = () => {
+  const toggleFollow = async () => {
+    setIsLoading(true);
+
+    const previousState = isFollowing;
     setIsFollowing((prev) => !prev);
 
-    // 외부에서 전달받은 onClick 함수 실행
-    if (onClick) {
-      onClick();
+    try {
+      if (previousState) {
+        await deleteFollow(followUserId);
+      } else {
+        await postFollow(followUserId);
+      }
+      setIsLoading(false);
+    } catch (error) {
+      setIsFollowing(previousState);
+      setIsLoading(false);
     }
   };
 
@@ -39,6 +52,7 @@ const FollowButton = ({
         hover:bg-opacity-80 active:bg-opacity-60 active:scale-95
         transition-all duration-300 ease-in-out
       `}
+      disabled={isLoading}
     >
       {isFollowing ? (
         <>

--- a/src/components/Button/FollowButton.tsx
+++ b/src/components/Button/FollowButton.tsx
@@ -7,14 +7,12 @@ import { FollowButtonProps } from '@/types/buttons/FollowButtonProps';
 import Icon from '../Icon/Icon';
 
 const FollowButton = ({
-  backgroundColor = 'bg-gray-800',
-  textColor = 'text-white',
   textSize = 'button-s',
-
+  initFollowState = false,
   onClick,
   ariaLabel,
 }: FollowButtonProps) => {
-  const [isFollowing, setIsFollowing] = useState(false);
+  const [isFollowing, setIsFollowing] = useState(initFollowState);
 
   const toggleFollow = () => {
     setIsFollowing((prev) => !prev);
@@ -32,10 +30,10 @@ const FollowButton = ({
       className={`
         button-s flex items-center justify-center rounded-full
         w-[95px] h-[37px] gap-[3px] ml-auto
-        ${backgroundColor} ${textColor} ${textSize}
+        ${textSize}
         ${
           isFollowing
-            ? 'border	border-gray-300 text-gray-300 bg-transparent'
+            ? 'border	border-gray-900 text-gray-900 bg-white'
             : 'bg-gray-800 text-white'
         }
         hover:bg-opacity-80 active:bg-opacity-60 active:scale-95

--- a/src/components/Button/FollowButton.tsx
+++ b/src/components/Button/FollowButton.tsx
@@ -10,7 +10,7 @@ import Icon from '../Icon/Icon';
 
 const FollowButton = ({
   textSize = 'button-s',
-  initFollowState = false,
+  initFollowState,
   ariaLabel,
   followUserId,
 }: FollowButtonProps) => {

--- a/src/components/Button/FollowButton.tsx
+++ b/src/components/Button/FollowButton.tsx
@@ -29,9 +29,9 @@ const FollowButton = ({
       } else {
         await postFollow(followUserId);
       }
-      setIsLoading(false);
     } catch (error) {
       setIsFollowing(previousState);
+    } finally {
       setIsLoading(false);
     }
   };

--- a/src/components/Card/ArtistProfileCard.tsx
+++ b/src/components/Card/ArtistProfileCard.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import Image from 'next/image';
+
+import DefaultImage from '@/../public/images/defaultArtworkImage.png';
+import DefaultProfileImage from '@/../public/images/defaultProfileImage.png';
+import RankingLabel from '@/../public/images/rankingLabel.png';
+import FollowButton from '../Button/FollowButton';
+
+interface ArtistProfileCardProps {
+  rank: number;
+  artistInfo: ArtistInfoType;
+}
+
+const ArtistProfileCard = ({ rank, artistInfo }: ArtistProfileCardProps) => {
+  const {
+    profileImage,
+    nickname,
+    userField,
+    introduction,
+    isFollow,
+    artworkImage,
+  } = artistInfo;
+
+  const formattedRank = rank < 10 ? `0${rank}` : rank;
+
+  return (
+    <div className='relative w-[346px] h-[330px] rounded-[10px] overflow-hidden'>
+      {/* badge */}
+      <div className='absolute left-[30px] top-0 z-10'>
+        <Image src={RankingLabel} alt='ranking-label' width={33} height={48} />
+        <p className='absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 placeholder'>
+          {formattedRank}
+        </p>
+      </div>
+      {/* image */}
+      {artworkImage ? (
+        <Image
+          src={artworkImage}
+          alt='artworks'
+          fill={true}
+          className='object-contain'
+        />
+      ) : (
+        <Image src={DefaultImage} alt='artwork=default-image' fill={true} />
+      )}
+
+      {/* info */}
+      <div className='absolute left-0 bottom-0 w-full pt-10 pb-[15px] px-[30px] bg-white'>
+        {/* profile thumbnail */}
+        <div className='absolute left-[30px] -top-[34px] w-[69px] h-[69px] rounded-full overflow-hidden'>
+          {profileImage ? (
+            <Image src={profileImage} alt='user-profile' />
+          ) : (
+            <Image src={DefaultProfileImage} alt='default-profile' />
+          )}
+        </div>
+        {/* profile info */}
+        <div className='flex flex-col gap-[10px] '>
+          <div className='flex justify-between'>
+            <p className='subtitle2 text-gray-900'>{nickname}</p>
+            <FollowButton initFollowState={isFollow} />
+          </div>
+          <p className='placeholder text-gray-500'>{userField}</p>
+          <p className='body2 text-gray-500'>{introduction}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ArtistProfileCard;

--- a/src/components/Card/ArtistProfileCard.tsx
+++ b/src/components/Card/ArtistProfileCard.tsx
@@ -14,6 +14,7 @@ interface ArtistProfileCardProps {
 
 const ArtistProfileCard = ({ rank, artistInfo }: ArtistProfileCardProps) => {
   const {
+    userId,
     profileImage,
     nickname,
     userField,
@@ -59,7 +60,7 @@ const ArtistProfileCard = ({ rank, artistInfo }: ArtistProfileCardProps) => {
         <div className='flex flex-col gap-[10px] '>
           <div className='flex justify-between'>
             <p className='subtitle2 text-gray-900'>{nickname}</p>
-            <FollowButton initFollowState={isFollow} />
+            <FollowButton initFollowState={isFollow} followUserId={userId} />
           </div>
           <p className='placeholder text-gray-500'>{userField}</p>
           <p className='body2 text-gray-500'>{introduction}</p>

--- a/src/components/Card/ArtistProfileCard.tsx
+++ b/src/components/Card/ArtistProfileCard.tsx
@@ -50,11 +50,7 @@ const ArtistProfileCard = ({ rank, artistInfo }: ArtistProfileCardProps) => {
       <div className='absolute left-0 bottom-0 w-full pt-10 pb-[15px] px-[30px] bg-white'>
         {/* profile thumbnail */}
         <div className='absolute left-[30px] -top-[34px] w-[69px] h-[69px] rounded-full overflow-hidden'>
-          {profileImage ? (
-            <Image src={profileImage} alt='user-profile' />
-          ) : (
-            <Image src={DefaultProfileImage} alt='default-profile' />
-          )}
+          <Image src={profileImage ?? DefaultProfileImage} alt='user-profile' />
         </div>
         {/* profile info */}
         <div className='flex flex-col gap-[10px] '>

--- a/src/components/Carousel/CarouselIndicator.tsx
+++ b/src/components/Carousel/CarouselIndicator.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { EmblaCarouselType } from 'embla-carousel';
+import React, {
+  ComponentPropsWithRef,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
+
+type UseIndicatorButtonType = {
+  selectedIndex: number;
+  scrollSnaps: number[];
+  onIndicatorButtonClick: (index: number) => void;
+};
+
+export const useIndicatorButton = (
+  emblaApi: EmblaCarouselType | undefined,
+  onButtonClick?: (emblaApi: EmblaCarouselType) => void,
+): UseIndicatorButtonType => {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
+
+  const onIndicatorButtonClick = useCallback(
+    (index: number) => {
+      if (!emblaApi) return;
+      emblaApi.scrollTo(index);
+      if (onButtonClick) onButtonClick(emblaApi);
+    },
+    [emblaApi, onButtonClick],
+  );
+
+  const onInit = useCallback((emblaApi: EmblaCarouselType) => {
+    setScrollSnaps(emblaApi.scrollSnapList());
+  }, []);
+
+  const onSelect = useCallback((emblaApi: EmblaCarouselType) => {
+    setSelectedIndex(emblaApi.selectedScrollSnap());
+  }, []);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    onInit(emblaApi);
+    onSelect(emblaApi);
+    emblaApi.on('reInit', onInit).on('reInit', onSelect).on('select', onSelect);
+  }, [emblaApi, onInit, onSelect]);
+
+  return {
+    selectedIndex,
+    scrollSnaps,
+    onIndicatorButtonClick,
+  };
+};
+
+type PropType = ComponentPropsWithRef<'button'>;
+
+export const IndicatorButton: React.FC<PropType> = (props) => {
+  const { children, ...restProps } = props;
+
+  return (
+    <button type='button' {...restProps}>
+      {children}
+    </button>
+  );
+};

--- a/src/components/Carousel/ControllableCarousel.tsx
+++ b/src/components/Carousel/ControllableCarousel.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { usePrevNextButtons } from '@/hooks/usePrevNextButtons';
+import useEmblaCarousel from 'embla-carousel-react';
+import { IndicatorButton, useIndicatorButton } from './CarouselIndicator';
+
+import { ReactNode } from 'react';
+import ChevronLeft from '../Icon/icons/ChevronLeft';
+import ChevronRight from '../Icon/icons/ChevronRight';
+
+type ControlledCarouselPropsType<T> = {
+  slides: T[];
+  renderSlide: (card: T, index: number) => ReactNode;
+  spaceSize?: 's' | 'm' | 'l';
+};
+
+const ControlledCarousel = <T,>({
+  slides,
+  renderSlide,
+  spaceSize = 'm',
+}: ControlledCarouselPropsType<T>) => {
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    dragFree: true,
+  });
+
+  const { selectedIndex, scrollSnaps, onIndicatorButtonClick } =
+    useIndicatorButton(emblaApi);
+
+  const {
+    prevBtnDisabled,
+    nextBtnDisabled,
+    onPrevButtonClick,
+    onNextButtonClick,
+  } = usePrevNextButtons(emblaApi);
+
+  const [gapSizeClassName, padddingSizeClassName] =
+    spaceSize === 'l'
+      ? ['ml-[-45px] mobile:ml-[-50px]', 'pl-[45px] mobile:pl-[50px]']
+      : spaceSize === 'm'
+        ? ['ml-[-35px] mobile:ml-[-45px]', 'pl-[35px] mobile:pl-[45px]']
+        : ['ml-[-30px]', 'pl-[30px]'];
+
+  return (
+    <section className='relative flex flex-col gap-[90px]'>
+      <div className='absolute -top-[120px] right-0  hidden tablet:flex'>
+        <button
+          type='button'
+          className='touch-manipulation  cursor-pointer w-[60px] h-[60px] rounded-full  disabled:text-gray-800'
+          onClick={onPrevButtonClick}
+          disabled={prevBtnDisabled}
+        >
+          <ChevronLeft
+            className={`${prevBtnDisabled ? 'text-gray-800' : 'text-gray-200'}`}
+          />
+        </button>
+        <button
+          type='button'
+          className='touch-manipulation  cursor-pointer w-[60px] h-[60px] rounded-full  disabled:text-gray-800'
+          onClick={onNextButtonClick}
+          disabled={nextBtnDisabled}
+        >
+          <ChevronRight
+            className={`${nextBtnDisabled ? 'text-gray-800' : 'text-gray-200'}`}
+          />
+        </button>
+      </div>
+
+      <div className='max-w-[1980px] overflow-hidden' ref={emblaRef}>
+        <div
+          className={`flex backface-hidden touch-pan-y pinch-zoom ${gapSizeClassName}`}
+        >
+          {slides.map((item, index) => (
+            <div
+              className={`min-w-0 flex-[0_0_fit-content] ${padddingSizeClassName}`}
+              key={index}
+            >
+              {renderSlide(item, index)}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className='flex w-full h-[10px] bg-gray-900 rounded-[10px] overflow-hidden'>
+        {scrollSnaps.map((_, index) => (
+          <IndicatorButton
+            key={index}
+            onClick={() => onIndicatorButtonClick(index)}
+            className={`w-full h-[10px] flex rounded-[10px] transition-all duration-300 ease-in-out ${index === selectedIndex ? ' bg-main ' : ''}`}
+          />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default ControlledCarousel;

--- a/src/components/Carousel/ControllableCarousel.tsx
+++ b/src/components/Carousel/ControllableCarousel.tsx
@@ -5,8 +5,7 @@ import useEmblaCarousel from 'embla-carousel-react';
 import { IndicatorButton, useIndicatorButton } from './CarouselIndicator';
 
 import { ReactNode } from 'react';
-import ChevronLeft from '../Icon/icons/ChevronLeft';
-import ChevronRight from '../Icon/icons/ChevronRight';
+import Icon from '../Icon/Icon';
 
 type ControlledCarouselPropsType<T> = {
   slides: T[];
@@ -49,7 +48,9 @@ const ControlledCarousel = <T,>({
           onClick={onPrevButtonClick}
           disabled={prevBtnDisabled}
         >
-          <ChevronLeft
+          <Icon
+            name='ChevronRight'
+            size='s'
             className={`${prevBtnDisabled ? 'text-gray-800' : 'text-gray-200'}`}
           />
         </button>
@@ -59,7 +60,9 @@ const ControlledCarousel = <T,>({
           onClick={onNextButtonClick}
           disabled={nextBtnDisabled}
         >
-          <ChevronRight
+          <Icon
+            name='ChevronLeft'
+            size='s'
             className={`${nextBtnDisabled ? 'text-gray-800' : 'text-gray-200'}`}
           />
         </button>

--- a/src/constants/API.ts
+++ b/src/constants/API.ts
@@ -4,6 +4,7 @@ const USER = {
   socialSignIn: '/user/login/social',
   validateEmail: '/user/validation/email',
   validateNickname: '/user/validation/nickname',
+  follow: '/user/follow',
 };
 
 export { USER };

--- a/src/hooks/usePrevNextButtons.tsx
+++ b/src/hooks/usePrevNextButtons.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { EmblaCarouselType } from 'embla-carousel';
+import { useCallback, useEffect, useState } from 'react';
+
+type UsePrevNextButtonsType = {
+  prevBtnDisabled: boolean;
+  nextBtnDisabled: boolean;
+  onPrevButtonClick: () => void;
+  onNextButtonClick: () => void;
+};
+
+export const usePrevNextButtons = (
+  emblaApi: EmblaCarouselType | undefined,
+  onButtonClick?: (emblaApi: EmblaCarouselType) => void,
+): UsePrevNextButtonsType => {
+  const [prevBtnDisabled, setPrevBtnDisabled] = useState(true);
+  const [nextBtnDisabled, setNextBtnDisabled] = useState(true);
+
+  const onPrevButtonClick = useCallback(() => {
+    if (!emblaApi) return;
+    emblaApi.scrollPrev();
+    if (onButtonClick) onButtonClick(emblaApi);
+  }, [emblaApi, onButtonClick]);
+
+  const onNextButtonClick = useCallback(() => {
+    if (!emblaApi) return;
+    emblaApi.scrollNext();
+    if (onButtonClick) onButtonClick(emblaApi);
+  }, [emblaApi, onButtonClick]);
+
+  const onSelect = useCallback((emblaApi: EmblaCarouselType) => {
+    setPrevBtnDisabled(!emblaApi.canScrollPrev());
+    setNextBtnDisabled(!emblaApi.canScrollNext());
+  }, []);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+
+    onSelect(emblaApi);
+    emblaApi.on('reInit', onSelect).on('select', onSelect);
+  }, [emblaApi, onSelect]);
+
+  return {
+    prevBtnDisabled,
+    nextBtnDisabled,
+    onPrevButtonClick,
+    onNextButtonClick,
+  };
+};

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -1,0 +1,9 @@
+interface ArtistInfoType {
+  userId: number;
+  profileImage: string;
+  nickname: string;
+  userField: string;
+  introduction: string;
+  isFollow: boolean;
+  artworkImage: string;
+}

--- a/src/types/buttons/FollowButtonProps.ts
+++ b/src/types/buttons/FollowButtonProps.ts
@@ -6,4 +6,5 @@ export interface FollowButtonProps
     'children' | 'disabled' | 'loading' | 'icon' | 'iconPosition' | 'type'
   > {
   initFollowState?: boolean;
+  followUserId: number;
 }

--- a/src/types/buttons/FollowButtonProps.ts
+++ b/src/types/buttons/FollowButtonProps.ts
@@ -5,6 +5,6 @@ export interface FollowButtonProps
     BaseButtonProps,
     'children' | 'disabled' | 'loading' | 'icon' | 'iconPosition' | 'type'
   > {
-  initFollowState?: boolean;
+  initFollowState: boolean;
   followUserId: number;
 }

--- a/src/types/buttons/FollowButtonProps.ts
+++ b/src/types/buttons/FollowButtonProps.ts
@@ -4,4 +4,6 @@ export interface FollowButtonProps
   extends Omit<
     BaseButtonProps,
     'children' | 'disabled' | 'loading' | 'icon' | 'iconPosition' | 'type'
-  > {}
+  > {
+  initFollowState?: boolean;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,6 +49,10 @@ export default {
         '78.25': '313px',
       },
     },
+    screens: {
+      mobile: '677px',
+      tablet: '1400px',
+    },
   },
   plugins: [
     nextui({


### PR DESCRIPTION
## 📝 작업 내용
- 작가 카드 컴포넌트와 컨트롤러가 있는 케로셀을 구현하였습니다.
- 작가 카드 내 팔로우 버튼의 클릭 이벤트를 추가하였습니다.
- Following 여부에 따라 Follow 버튼의 글자 색상이 변하지 않는 이슈가 있어서 일부 스타일을 수정하였습니다!
- 반응형 컴포넌트가 있어 내부에 break 포인트를 추가하였습니다.

## 📸 스크린샷
<img width="765" alt="image" src="https://github.com/user-attachments/assets/214326ad-5619-4b4d-a1ca-c1311a058ed9" />

![Dec-30-2024 16-13-45](https://github.com/user-attachments/assets/a01e032c-2fa7-485a-918e-80e60c9956c1)


## 💬 리뷰 요구사항
- break point의 경우 피그마에 정의해둔 대로 1400, 677 기준으로 분리하였습니다..!
- 팔로우 언팔로우의 경우 204 response를 MSW로 테스트하는 방법을 아직 못찾아서 다른 방식으로 테스트 한 후에 추가하였습니다!
- 이후 인증이 필요한 api들은 authorizedClient를 통해 api 요청을 보내려고합니다. 현재 토큰 관련 로직이 포함되어 있지 않아서 네이밍만 `authorizedClient`인 점 참고 부탁드립니다. 이후 메인 페이지 작업 내용 리뷰 완료 되는대로 나머지 API 작업 시작하겠습니다.