### PR TITLE
[FIX] feat: 팔로우한 작가 api reseponse 타입 추가

### DIFF
--- a/src/apis/artwork/getFollowedArtists.ts
+++ b/src/apis/artwork/getFollowedArtists.ts
@@ -2,10 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 
 import { authorizedClient } from '@/apis';
 import { ARTWORK } from '@/constants/API';
+import { FollowedArtistsResponse } from '@/types';
 
 const getFollowedArtists = async () => {
   try {
-    const response = await authorizedClient.get(ARTWORK.followedArtists);
+    const response = await authorizedClient.get<FollowedArtistsResponse>(
+      ARTWORK.followedArtists,
+    );
     return response.data.posts;
   } catch (error) {
     console.error('내가 팔로우한 작가 조회 중 에러 발생: ', error);
@@ -14,10 +17,16 @@ const getFollowedArtists = async () => {
 };
 
 const useFollowedArtists = () => {
-  return useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: [ARTWORK.followedArtists],
     queryFn: getFollowedArtists,
   });
+
+  return {
+    data: data ?? [],
+    isLoading,
+    error,
+  };
 };
 
 export default useFollowedArtists;


### PR DESCRIPTION
## 📝 작업 내용
- 작품 목록 페이지의 `팔로우한 작가 리스트`와 관련한 api 로직 내에서 `FollowedArtistTypes`를 추가하여 타입 추론을 가능하게 함.
- 해당 api로 표시되는 DefaultCarousel 컴포넌트 로직에 코드 상 충돌 부분이 없는 것으로 확인 

## 💬 리뷰 요구사항
- 해당 부분이 노션 문서에서 전달해주신 `response 타입 지정 가능하도록 DefaultCarousel 의 props 타입 조정`과 일치하는 부분인지 확인 부탁드립니다!
