### PR TITLE
[TASK-72] refactor: 모달 구현 로직 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,6 @@ const RootLayout = ({ children, modal }: Readonly<LayoutProps>) => {
         <MSWProvider>
           <TanStackQueryProvider>
             <AppShell>{children}</AppShell>
-            {modal}
           </TanStackQueryProvider>
         </MSWProvider>
         <KakaoProvider />

--- a/src/app/providers/ModalProvider.tsx
+++ b/src/app/providers/ModalProvider.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useStore } from 'zustand';
 
 import modalStore from '@/stores/modalStore';
 
-const ModalPage = () => {
+const ModalProvider = () => {
   const { isOpen, modalSize, contents } = useStore(modalStore);
 
   useEffect(() => {
@@ -23,19 +24,18 @@ const ModalPage = () => {
     lg: 'tablet:w-[1011px] rounded-[20px]',
   };
 
-  return (
-    <>
-      {isOpen && (
-        <div className='fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50'>
-          <div
-            className={`${modalClassNames[modalSize]} absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[366px] h-content bg-background-overlay text-black`}
-          >
-            {contents}
-          </div>
-        </div>
-      )}
-    </>
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div className='fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50'>
+      <div
+        className={`${modalClassNames[modalSize]} absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[366px] h-content bg-background-overlay text-black`}
+      >
+        {contents}
+      </div>
+    </div>,
+    document.body,
   );
 };
 
-export default ModalPage;
+export default ModalProvider;

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -4,6 +4,7 @@ import { NextUIProvider } from '@nextui-org/react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import { ReactNode } from 'react';
 
+import ModalProvider from '@/app/providers/ModalProvider';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/Navbar';
 
@@ -25,6 +26,7 @@ const AppShell = ({ children }: { children: ReactNode }) => {
             </main>
             <Footer />
           </div>
+          <ModalProvider />
         </NextThemesProvider>
       </NextUIProvider>
     </>

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -28,7 +28,7 @@ const modalStore = create<ModalState & ModalAction>((set) => ({
     set((state) => {
       if (state.isOpen) return state;
 
-      return { isOpen: true, ...props };
+      return { ...state, isOpen: true, ...props };
     }),
   closeModal: () =>
     set((state) => {


### PR DESCRIPTION
## 📝 작업 내용
- 모달 구현 로직을 변경하였습니다.

기존 Parrallel Route와 전역 상태 관리를 활용하여 모달을 구현하였는데, Parrallel Route에 대해서 제대로 파악하지 않고 구현을 한 나머지, Parrallel Route는 동일한 레벨의 layout에만 적용 가능한 점을 파악하지 못한채 구현하여 artwork/detail과 같은 하위 라우트에서는 활용이 불가능한 점이 있었습니다.
그래서 기존 로직을 수정하여 Ract Portal 과 전역 상태 관리 로직을 활용하여 기존 사용법을 유지한 상태에서 로직을 수정하였습니다.

Parrallel Route를 계속 사용할 수도 있지만 모달이 필요한 영역에서 모두 layout 작업과 모달 형태 별 Parrallel Route 작업을 해주어아해서 app디렉토리의 복잡도가 높아질 것이 우려되어, 앞서 설명한 Portal을 채택하여 구현하게 되었습니다.

혼동드려 죄송합니다.
