### PR TITLE
[TASK-92, TASK-93, TASK-94] style: 작품 업로드 페이지 UI 구현

### DIFF
--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -1,28 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 import OvalButton from '@/components/Button/OvalButton';
 import FilterDropdown from '@/components/FilterDropdown';
 import Icon from '@/components/Icon/Icon';
 import BasicInput from '@/components/Input/BasicInput';
 
+interface ArtworkField {
+  name: string;
+  value: string;
+}
+
 const MAX_TITLE_LENGTH = 50;
 const MAX_DESCRIPTION_LENGTH = 1000;
 
 const PRIVACY_SETTING_OPTIONS = [
-  {
-    name: '전체공개',
-    value: 'PUBLIC',
-  },
-  {
-    name: '비공개',
-    value: 'PRIVATE',
-  },
+  { name: '전체공개', value: 'PUBLIC' },
+  { name: '비공개', value: 'PRIVATE' },
 ];
 
-const ARTWORK_FIELDS = [
-  { name: '전체', value: 'ALL' },
+const ARTWORK_FIELDS: ArtworkField[] = [
   { name: '회화', value: 'PAINTING' },
   { name: '공예/조각', value: 'CRAFTSCULPTURE' },
   { name: '드로잉', value: 'DRAWING' },
@@ -34,47 +32,105 @@ const ARTWORK_FIELDS = [
   { name: '기타', value: 'OTHERS' },
 ];
 
-interface ArtworkFilterProps {
-  selectedArtworkField: string;
-  setSelectedArtworkField: (value: string | ((prev: string) => string)) => void;
-  selectedFilter: string;
-  setSelectedFilter: (value: string | ((prev: string) => string)) => void;
-  setCurrentPage: (value: number | ((prev: number) => number)) => void;
-}
-
-interface ArtworkField {
-  name: string;
-  value: string;
-}
-
 const ArtworkUpload = () => {
   const [artworkTitle, setArtworkTitle] = useState('');
   const [selectedArtworkField, setSelectedArtworkField] = useState('');
-  const [privacySetting, setPrivacySetting] = useState<'public' | 'private'>(
-    'public',
+  const [privacySetting, setPrivacySetting] = useState<'전체공개' | '비공개'>(
+    '전체공개',
   );
+  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
   const [artworkDescription, setArtworkDescription] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<{
+    artworkTitle?: string;
+    selectedArtworkField?: string;
+    uploadedImage?: string;
+  }>({
+    artworkTitle: '',
+    selectedArtworkField: '',
+    uploadedImage: '',
+  });
 
-  const handleArtworkTitleOnChange = (e: any) => {
+  const handleArtworkTitleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
     setArtworkTitle(e.target.value);
+
+    if (errors.artworkTitle) {
+      setErrors((prevErrors) => ({ ...prevErrors, artworkTitle: '' }));
+    }
   };
 
-  const selectedArtworkFieldName =
-    ARTWORK_FIELDS.find((field) => field.value === selectedArtworkField)
-      ?.name || '전체';
+  const handlertworkDescriptionOnChange = (
+    e: ChangeEvent<HTMLInputElement>,
+  ) => {
+    setArtworkDescription(e.target.value);
+  };
 
   const handleArtworkFieldClick = (artworkField: string) => {
     setSelectedArtworkField(artworkField);
+
+    if (!artworkTitle.trim()) {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        artworkTitle: '필수 항목입니다.',
+      }));
+    } else {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        artworkTitle: '',
+      }));
+    }
+
+    if (errors.selectedArtworkField) {
+      setErrors((prevErrors) => ({
+        ...prevErrors,
+        selectedArtworkField: '',
+      }));
+    }
   };
 
   const handlePrivacySettingChange = (
-    newPrivacySetting: 'public' | 'private',
+    newPrivacySetting: '전체공개' | '비공개',
   ) => {
     setPrivacySetting(newPrivacySetting);
   };
 
-  const handlertworkDescriptionOnChange = (e: any) => {
-    setArtworkDescription(e.target.value);
+  const handleImageUpload = () => {
+    // TODO: 실제 이미지 업로드 로직 구현
+    setUploadedImage('uploaded-image-url'); // 테스트용
+
+    if (errors.uploadedImage) {
+      setErrors((prevErrors) => ({ ...prevErrors, uploadedImage: '' }));
+    }
+  };
+
+  const validateArtworkUploadForm = () => {
+    const newErrors: {
+      artworkTitle?: string;
+      selectedArtworkField?: string;
+      uploadedImage?: string;
+    } = {};
+
+    if (!artworkTitle.trim()) newErrors.artworkTitle = '필수 항목입니다.';
+    if (!selectedArtworkField.trim())
+      newErrors.selectedArtworkField = '필수 항목입니다.';
+    if (!uploadedImage) newErrors.uploadedImage = '이미지를 업로드해주세요.';
+    setErrors(newErrors);
+
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const isFormValid =
+    artworkTitle && selectedArtworkField && uploadedImage && !isSubmitting;
+
+  const handleArtworkUpload = () => {
+    if (!validateArtworkUploadForm()) return;
+    setIsSubmitting(true);
+
+    // TODO: 업로드 성공 시, 작성한 글 상세 페이지로 이동
+    // [테스트용] 업로드 처리 (API 호출)
+    setTimeout(() => {
+      console.log('업로드 완료');
+    }, 2000);
   };
 
   return (
@@ -89,22 +145,25 @@ const ArtworkUpload = () => {
           onChange={handleArtworkTitleOnChange}
           showTextLength={true}
           maxLength={MAX_TITLE_LENGTH}
-          // isInvalid={!!errors.artworkTitle}
-          // errorMessage={errors.artworkTitle?.message as string}
+          isInvalid={!!errors.artworkTitle}
+          errorMessage={errors.artworkTitle}
         />
       </div>
       <div className='flex flex-col md:flex-row items-start self-stretch gap-[38px] md:gap-[50px] pb-[78px]'>
         <FilterDropdown
           label='작품 카테고리'
           placeholder='카테고리 선택'
-          options={ARTWORK_FIELDS}
+          options={ARTWORK_FIELDS.map((field) => field.name)}
           selected={selectedArtworkField}
-          onClick={() => handleArtworkFieldClick(artworkField.value)}
+          onChange={(value) => handleArtworkFieldClick(value)}
+          isInvalid={!!errors.selectedArtworkField}
+          errorMessage={errors.selectedArtworkField}
           className='w-full'
         />
+
         <FilterDropdown
           label='공개범위'
-          options={PRIVACY_SETTING_OPTIONS}
+          options={PRIVACY_SETTING_OPTIONS.map((option) => option.name)}
           selected={privacySetting}
           onChange={() => handlePrivacySettingChange(privacySetting)}
           className='w-full'
@@ -125,13 +184,38 @@ const ArtworkUpload = () => {
             <br />
             작품 업로드 버튼을 눌러 이미지를 선택하세요.
           </p>
-          <OvalButton variant='primary' buttonSize='s'>
+          <OvalButton
+            variant='primary'
+            buttonSize='s'
+            onClick={handleImageUpload}
+          >
             <Icon name='UploadShare' size='m' className='mr-2.5' />
-            작품 업로드
+            이미지 업로드
           </OvalButton>
           <p className='button-s text-center text-gray-500'>
             작품 이미지는 1장만 업로드 가능합니다.
           </p>
+
+          {errors.uploadedImage && (
+            <div className='flex items-center mt-[3px] h-[26px]'>
+              <Icon
+                name='AlertCircle'
+                size='s'
+                className='text-system-error mr-2'
+              />
+              <p className='button-s text-system-error'>
+                {errors.uploadedImage}
+              </p>
+            </div>
+          )}
+
+          {uploadedImage && (
+            <img
+              src={uploadedImage}
+              alt='Uploaded Artwork'
+              className='mt-4 max-h-[200px] object-contain'
+            />
+          )}
 
           <button
             aria-label='Button to change artwork image'
@@ -163,7 +247,14 @@ const ArtworkUpload = () => {
         >
           취소
         </button>
-        <OvalButton variant='primary' buttonSize='s'>
+
+        {/* hover:cursor-not-allowed */}
+        <OvalButton
+          variant={`${!isSubmitting && isFormValid ? 'primary' : 'secondary'}`}
+          buttonSize='s'
+          disabled={isSubmitting && !isFormValid}
+          onClick={handleArtworkUpload}
+        >
           업로드
         </OvalButton>
       </div>

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -6,31 +6,28 @@ import OvalButton from '@/components/Button/OvalButton';
 import FilterDropdown from '@/components/FilterDropdown';
 import Icon from '@/components/Icon/Icon';
 import BasicInput from '@/components/Input/BasicInput';
+import ARTWORK_FIELDS from '@/constants/artworkFields';
 
-interface ArtworkField {
-  name: string;
-  value: string;
+import Textarea from '../../../components/Input/Textarea';
+
+interface ArtworkFieldsErrors {
+  artworkTitleError?: string;
+  selectedArtworkFieldError?: string;
+  uploadedImageError?: string;
 }
 
 const MAX_TITLE_LENGTH = 50;
 const MAX_DESCRIPTION_LENGTH = 1000;
+const REQUIRED_FIELDS_ERROR_MESSAGE = '필수 항목입니다.';
 
 const PRIVACY_SETTING_OPTIONS = [
   { name: '전체공개', value: 'PUBLIC' },
   { name: '비공개', value: 'PRIVATE' },
 ];
 
-const ARTWORK_FIELDS: ArtworkField[] = [
-  { name: '회화', value: 'PAINTING' },
-  { name: '공예/조각', value: 'CRAFTSCULPTURE' },
-  { name: '드로잉', value: 'DRAWING' },
-  { name: '판화', value: 'PRINTMAKING' },
-  { name: '서예', value: 'CALLIGRAPHY' },
-  { name: '일러스트', value: 'ILLUSTRATION' },
-  { name: '디지털아트', value: 'DIGITALART' },
-  { name: '사진', value: 'PHOTOGRAPHY' },
-  { name: '기타', value: 'OTHERS' },
-];
+const ARTWORK_FIELDS_NOT_INCLUDED_ALL = ARTWORK_FIELDS.filter(
+  (field) => field.value !== 'ALL',
+);
 
 const ArtworkUpload = () => {
   const [artworkTitle, setArtworkTitle] = useState('');
@@ -38,29 +35,27 @@ const ArtworkUpload = () => {
   const [privacySetting, setPrivacySetting] = useState<'전체공개' | '비공개'>(
     '전체공개',
   );
-  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+  const [uploadedImage, setUploadedImage] = useState<string>('');
   const [artworkDescription, setArtworkDescription] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errors, setErrors] = useState<{
-    artworkTitle?: string;
-    selectedArtworkField?: string;
-    uploadedImage?: string;
-  }>({
-    artworkTitle: '',
-    selectedArtworkField: '',
-    uploadedImage: '',
+  const [errors, setErrors] = useState<ArtworkFieldsErrors>({
+    artworkTitleError: '',
+    selectedArtworkFieldError: '',
+    uploadedImageError: '',
   });
 
-  const handleArtworkTitleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setArtworkTitle(e.target.value);
-
-    if (errors.artworkTitle) {
-      setErrors((prevErrors) => ({ ...prevErrors, artworkTitle: '' }));
-    }
+  const clearErrorMessage = (targetField: string) => {
+    setErrors((prevErrors) => ({ ...prevErrors, [targetField]: '' }));
   };
 
-  const handlertworkDescriptionOnChange = (
-    e: ChangeEvent<HTMLInputElement>,
+  const handleArtworkTitleChanged = (e: ChangeEvent<HTMLInputElement>) => {
+    setArtworkTitle(e.target.value);
+
+    if (errors.artworkTitleError) clearErrorMessage('artworkTitleError');
+  };
+
+  const handleArtworkDescriptionOnChange = (
+    e: ChangeEvent<HTMLTextAreaElement>,
   ) => {
     setArtworkDescription(e.target.value);
   };
@@ -71,21 +66,14 @@ const ArtworkUpload = () => {
     if (!artworkTitle.trim()) {
       setErrors((prevErrors) => ({
         ...prevErrors,
-        artworkTitle: '필수 항목입니다.',
+        artworkTitleError: REQUIRED_FIELDS_ERROR_MESSAGE,
       }));
     } else {
-      setErrors((prevErrors) => ({
-        ...prevErrors,
-        artworkTitle: '',
-      }));
+      clearErrorMessage('artworkTitleError');
     }
 
-    if (errors.selectedArtworkField) {
-      setErrors((prevErrors) => ({
-        ...prevErrors,
-        selectedArtworkField: '',
-      }));
-    }
+    if (errors.selectedArtworkFieldError)
+      clearErrorMessage('selectedArtworkFieldError');
   };
 
   const handlePrivacySettingChange = (
@@ -98,28 +86,24 @@ const ArtworkUpload = () => {
     // TODO: 실제 이미지 업로드 로직 구현
     setUploadedImage('uploaded-image-url'); // 테스트용
 
-    if (errors.uploadedImage) {
-      setErrors((prevErrors) => ({ ...prevErrors, uploadedImage: '' }));
-    }
+    if (errors.uploadedImageError) clearErrorMessage('uploadedImageError');
   };
 
   const validateArtworkUploadForm = () => {
-    const newErrors: {
-      artworkTitle?: string;
-      selectedArtworkField?: string;
-      uploadedImage?: string;
-    } = {};
+    const newErrors: ArtworkFieldsErrors = {};
 
-    if (!artworkTitle.trim()) newErrors.artworkTitle = '필수 항목입니다.';
+    if (!artworkTitle.trim())
+      newErrors.artworkTitleError = REQUIRED_FIELDS_ERROR_MESSAGE;
     if (!selectedArtworkField.trim())
-      newErrors.selectedArtworkField = '필수 항목입니다.';
-    if (!uploadedImage) newErrors.uploadedImage = '이미지를 업로드해주세요.';
+      newErrors.selectedArtworkFieldError = REQUIRED_FIELDS_ERROR_MESSAGE;
+    if (!uploadedImage)
+      newErrors.uploadedImageError = REQUIRED_FIELDS_ERROR_MESSAGE;
     setErrors(newErrors);
 
     return Object.keys(newErrors).length === 0;
   };
 
-  const isFormValid =
+  const isRequiredFieldsValid =
     artworkTitle && selectedArtworkField && uploadedImage && !isSubmitting;
 
   const handleScrollToTop = () => {
@@ -134,11 +118,8 @@ const ArtworkUpload = () => {
   const handleArtworkUpload = () => {
     setIsSubmitting(true);
 
-    // TODO: 업로드 성공 시, 작성한 글 상세 페이지로 이동
-    // [테스트용] 업로드 처리 (API 호출)
-    setTimeout(() => {
-      console.log('업로드 완료');
-    }, 2000);
+    console.log('업로드 완료'); // [테스트용] 업로드 처리 (API 호출)
+    // TODO: 작성한 글 상세 페이지로 이동
   };
 
   return (
@@ -150,22 +131,23 @@ const ArtworkUpload = () => {
           label='작품 제목'
           placeholder='작품 제목을 입력하세요.'
           value={artworkTitle}
-          onChange={handleArtworkTitleOnChange}
+          onChange={handleArtworkTitleChanged}
           showTextLength={true}
           maxLength={MAX_TITLE_LENGTH}
-          isInvalid={!!errors.artworkTitle}
-          errorMessage={errors.artworkTitle}
+          isInvalid={!!errors.artworkTitleError}
+          errorMessage={errors.artworkTitleError}
         />
       </div>
+
       <div className='flex flex-col md:flex-row items-start self-stretch gap-[38px] md:gap-[50px] pb-[78px]'>
         <FilterDropdown
           label='작품 카테고리'
           placeholder='카테고리 선택'
-          options={ARTWORK_FIELDS.map((field) => field.name)}
+          options={ARTWORK_FIELDS_NOT_INCLUDED_ALL.map((field) => field.name)}
           selected={selectedArtworkField}
           onChange={(value) => handleArtworkFieldClick(value)}
-          isInvalid={!!errors.selectedArtworkField}
-          errorMessage={errors.selectedArtworkField}
+          isInvalid={!!errors.selectedArtworkFieldError}
+          errorMessage={errors.selectedArtworkFieldError}
           className='w-full'
         />
 
@@ -204,15 +186,15 @@ const ArtworkUpload = () => {
             작품 이미지는 1장만 업로드 가능합니다.
           </p>
 
-          {errors.uploadedImage && (
-            <div className='flex items-center mt-[3px] h-[26px]'>
+          {errors.uploadedImageError && (
+            <div className='flex items-center'>
               <Icon
                 name='AlertCircle'
                 size='s'
                 className='text-system-error mr-2'
               />
               <p className='button-s text-system-error'>
-                {errors.uploadedImage}
+                {errors.uploadedImageError}
               </p>
             </div>
           )}
@@ -238,15 +220,15 @@ const ArtworkUpload = () => {
         </div>
       </div>
 
-      <BasicInput
-        type='textarea'
+      <Textarea
         label='작품 설명'
         placeholder='작품 설명을 입력하세요.'
         value={artworkDescription}
-        onChange={handlertworkDescriptionOnChange}
+        onChange={handleArtworkDescriptionOnChange}
         showTextLength={true}
         maxLength={MAX_DESCRIPTION_LENGTH}
       />
+
       <div className='pt-[30px] flex justify-end items-center gap-[20px]'>
         <button
           className='button-s text-gray-300 flex items-center justify-center rounded-full
@@ -256,7 +238,7 @@ const ArtworkUpload = () => {
           취소
         </button>
 
-        {!isSubmitting && isFormValid ? (
+        {!isSubmitting && isRequiredFieldsValid ? (
           <OvalButton
             variant='primary'
             buttonSize='s'

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -78,9 +78,9 @@ const ArtworkUpload = () => {
   };
 
   return (
-    <div className='max-w-[1920px] m-auto px-[36px] lg:px-[140px]'>
-      <h1 className='py-[70px]'>작품 업로드</h1>
-      <div className='pb-[40px]'>
+    <div className='max-w-[1920px] m-auto px-[36px] py-[70px] lg:px-[140px]'>
+      <h1>작품 업로드</h1>
+      <div className='pt-[70px] pb-[30px] md:pb-[40px]'>
         <BasicInput
           type='text'
           label='작품 제목'
@@ -93,7 +93,7 @@ const ArtworkUpload = () => {
           // errorMessage={errors.artworkTitle?.message as string}
         />
       </div>
-      <div className='flex items-start self-stretch gap-[50px] pb-[78px]'>
+      <div className='flex flex-col md:flex-row items-start self-stretch gap-[38px] md:gap-[50px] pb-[78px]'>
         <FilterDropdown
           label='작품 카테고리'
           placeholder='카테고리 선택'
@@ -110,9 +110,10 @@ const ArtworkUpload = () => {
           className='w-full'
         />
       </div>
-      <div className='relative'>
+
+      <div className='relative pb-[70px]'>
         <div
-          className='flex flex-col justify-center items-center gap-[15px] p-[140px] h-[853px]'
+          className='flex flex-col justify-center items-center gap-[15px] p-[140px] h-[511px] md:h-[853px]'
           style={{
             border: '2px dashed transparent',
             borderImage:
@@ -131,31 +132,40 @@ const ArtworkUpload = () => {
           <p className='button-s text-center text-gray-500'>
             작품 이미지는 1장만 업로드 가능합니다.
           </p>
+
+          <button
+            aria-label='Button to change artwork image'
+            className='flex justify-center items-center w-[57px] h-[57px] md:w-[77px] md:h-[77px]
+            absolute right-[30px] bottom-[30px] rounded-full
+            bg-[rgba(35,34,37,0.5)] backdrop-blur-[12px]
+            shadow-lg hover:bg-[rgba(35,34,37,0.7)] transition'
+          >
+            <Icon name='Image' size='m' className='block md:hidden' />
+            <Icon name='Image' size='l' className='hidden md:block' />
+          </button>
         </div>
       </div>
 
-      <div className='py-[70px]'>
-        <BasicInput
-          type='textarea'
-          label='작품 설명'
-          placeholder='작품 설명을 입력하세요.'
-          value={artworkDescription}
-          onChange={handlertworkDescriptionOnChange}
-          showTextLength={true}
-          maxLength={MAX_DESCRIPTION_LENGTH}
-        />
-        <div className='pt-[30px] flex justify-end items-center gap-[20px]'>
-          <button
-            className='button-s text-gray-300 flex items-center justify-center rounded-full
+      <BasicInput
+        type='textarea'
+        label='작품 설명'
+        placeholder='작품 설명을 입력하세요.'
+        value={artworkDescription}
+        onChange={handlertworkDescriptionOnChange}
+        showTextLength={true}
+        maxLength={MAX_DESCRIPTION_LENGTH}
+      />
+      <div className='pt-[30px] flex justify-end items-center gap-[20px]'>
+        <button
+          className='button-s text-gray-300 flex items-center justify-center rounded-full
             gap-[10px] px-[28px] leading-[50px]
-            transition-all duration-300 ease-in-out active:scale-95'
-          >
-            취소
-          </button>
-          <OvalButton variant='primary' buttonSize='s'>
-            업로드
-          </OvalButton>
-        </div>
+            transition-all duration-300 ease-in-out active:scale-95 hover:opacity-70'
+        >
+          취소
+        </button>
+        <OvalButton variant='primary' buttonSize='s'>
+          업로드
+        </OvalButton>
       </div>
     </div>
   );

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -139,7 +139,7 @@ const ArtworkUpload = () => {
   return (
     <div className='max-w-[1920px] m-auto px-[36px] py-[70px] lg:px-[140px]'>
       <h1>작품 업로드</h1>
-      <div className='pt-[70px] pb-[30px] md:pb-[40px]'>
+      <div className='pt-[70px] pb-[58px] md:pb-[40px]'>
         <BasicInput
           type='text'
           label='작품 제목'
@@ -251,15 +251,23 @@ const ArtworkUpload = () => {
           취소
         </button>
 
-        {/* hover:cursor-not-allowed */}
-        <OvalButton
-          variant={`${!isSubmitting && isFormValid ? 'primary' : 'secondary'}`}
-          buttonSize='s'
-          disabled={isSubmitting && !isFormValid}
-          onClick={handleArtworkUpload}
-        >
-          업로드
-        </OvalButton>
+        {!isSubmitting && isFormValid ? (
+          <OvalButton
+            variant='primary'
+            buttonSize='s'
+            onClick={handleArtworkUpload}
+          >
+            업로드
+          </OvalButton>
+        ) : (
+          <button
+            className='button-s text-gray-300 bg-gray-700 px-[28px] leading-[50px]
+            flex items-center justify-center rounded-full gap-[10px]
+            transition-all duration-300 ease-in-out active:scale-95 hover:opacity-70 hover:cursor-not-allowed'
+          >
+            업로드
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -1,5 +1,164 @@
+'use client';
+
+import { useState } from 'react';
+
+import OvalButton from '@/components/Button/OvalButton';
+import FilterDropdown from '@/components/FilterDropdown';
+import Icon from '@/components/Icon/Icon';
+import BasicInput from '@/components/Input/BasicInput';
+
+const MAX_TITLE_LENGTH = 50;
+const MAX_DESCRIPTION_LENGTH = 1000;
+
+const PRIVACY_SETTING_OPTIONS = [
+  {
+    name: '전체공개',
+    value: 'PUBLIC',
+  },
+  {
+    name: '비공개',
+    value: 'PRIVATE',
+  },
+];
+
+const ARTWORK_FIELDS = [
+  { name: '전체', value: 'ALL' },
+  { name: '회화', value: 'PAINTING' },
+  { name: '공예/조각', value: 'CRAFTSCULPTURE' },
+  { name: '드로잉', value: 'DRAWING' },
+  { name: '판화', value: 'PRINTMAKING' },
+  { name: '서예', value: 'CALLIGRAPHY' },
+  { name: '일러스트', value: 'ILLUSTRATION' },
+  { name: '디지털아트', value: 'DIGITALART' },
+  { name: '사진', value: 'PHOTOGRAPHY' },
+  { name: '기타', value: 'OTHERS' },
+];
+
+interface ArtworkFilterProps {
+  selectedArtworkField: string;
+  setSelectedArtworkField: (value: string | ((prev: string) => string)) => void;
+  selectedFilter: string;
+  setSelectedFilter: (value: string | ((prev: string) => string)) => void;
+  setCurrentPage: (value: number | ((prev: number) => number)) => void;
+}
+
+interface ArtworkField {
+  name: string;
+  value: string;
+}
+
 const ArtworkUpload = () => {
-  return <div>ArtworkUpload</div>;
+  const [artworkTitle, setArtworkTitle] = useState('');
+  const [selectedArtworkField, setSelectedArtworkField] = useState('');
+  const [privacySetting, setPrivacySetting] = useState<'public' | 'private'>(
+    'public',
+  );
+  const [artworkDescription, setArtworkDescription] = useState('');
+
+  const handleArtworkTitleOnChange = (e: any) => {
+    setArtworkTitle(e.target.value);
+  };
+
+  const selectedArtworkFieldName =
+    ARTWORK_FIELDS.find((field) => field.value === selectedArtworkField)
+      ?.name || '전체';
+
+  const handleArtworkFieldClick = (artworkField: string) => {
+    setSelectedArtworkField(artworkField);
+  };
+
+  const handlePrivacySettingChange = (
+    newPrivacySetting: 'public' | 'private',
+  ) => {
+    setPrivacySetting(newPrivacySetting);
+  };
+
+  const handlertworkDescriptionOnChange = (e: any) => {
+    setArtworkDescription(e.target.value);
+  };
+
+  return (
+    <div className='max-w-[1920px] m-auto px-[36px] lg:px-[140px]'>
+      <h1 className='py-[70px]'>작품 업로드</h1>
+      <div className='pb-[40px]'>
+        <BasicInput
+          type='text'
+          label='작품 제목'
+          placeholder='작품 제목을 입력하세요.'
+          value={artworkTitle}
+          onChange={handleArtworkTitleOnChange}
+          showTextLength={true}
+          maxLength={MAX_TITLE_LENGTH}
+          // isInvalid={!!errors.artworkTitle}
+          // errorMessage={errors.artworkTitle?.message as string}
+        />
+      </div>
+      <div className='flex items-start self-stretch gap-[50px] pb-[78px]'>
+        <FilterDropdown
+          label='작품 카테고리'
+          placeholder='카테고리 선택'
+          options={ARTWORK_FIELDS}
+          selected={selectedArtworkField}
+          onClick={() => handleArtworkFieldClick(artworkField.value)}
+          className='w-full'
+        />
+        <FilterDropdown
+          label='공개범위'
+          options={PRIVACY_SETTING_OPTIONS}
+          selected={privacySetting}
+          onChange={() => handlePrivacySettingChange(privacySetting)}
+          className='w-full'
+        />
+      </div>
+      <div className='relative'>
+        <div
+          className='flex flex-col justify-center items-center gap-[15px] p-[140px] h-[853px]'
+          style={{
+            border: '2px dashed transparent',
+            borderImage:
+              'repeating-linear-gradient(45deg, gray 0, gray 10px, transparent 10px, transparent 20px) 1',
+          }}
+        >
+          <p className='body2 text-center text-gray-500 self-stretch'>
+            첨부할 작품 이미지를 끌어오거나,
+            <br />
+            작품 업로드 버튼을 눌러 이미지를 선택하세요.
+          </p>
+          <OvalButton variant='primary' buttonSize='s'>
+            <Icon name='UploadShare' size='m' className='mr-2.5' />
+            작품 업로드
+          </OvalButton>
+          <p className='button-s text-center text-gray-500'>
+            작품 이미지는 1장만 업로드 가능합니다.
+          </p>
+        </div>
+      </div>
+
+      <div className='py-[70px]'>
+        <BasicInput
+          type='textarea'
+          label='작품 설명'
+          placeholder='작품 설명을 입력하세요.'
+          value={artworkDescription}
+          onChange={handlertworkDescriptionOnChange}
+          showTextLength={true}
+          maxLength={MAX_DESCRIPTION_LENGTH}
+        />
+        <div className='pt-[30px] flex justify-end items-center gap-[20px]'>
+          <button
+            className='button-s text-gray-300 flex items-center justify-center rounded-full
+            gap-[10px] px-[28px] leading-[50px]
+            transition-all duration-300 ease-in-out active:scale-95'
+          >
+            취소
+          </button>
+          <OvalButton variant='primary' buttonSize='s'>
+            업로드
+          </OvalButton>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default ArtworkUpload;

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -123,7 +123,10 @@ const ArtworkUpload = () => {
     artworkTitle && selectedArtworkField && uploadedImage && !isSubmitting;
 
   const handleArtworkUpload = () => {
-    if (!validateArtworkUploadForm()) return;
+    if (!validateArtworkUploadForm()) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
     setIsSubmitting(true);
 
     // TODO: 업로드 성공 시, 작성한 글 상세 페이지로 이동

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -25,10 +25,6 @@ const PRIVACY_SETTING_OPTIONS = [
   { name: '비공개', value: 'PRIVATE' },
 ];
 
-const ARTWORK_FIELDS_NOT_INCLUDED_ALL = ARTWORK_FIELDS.filter(
-  (field) => field.value !== 'ALL',
-);
-
 const ArtworkUpload = () => {
   const [artworkTitle, setArtworkTitle] = useState('');
   const [selectedArtworkField, setSelectedArtworkField] = useState('');
@@ -143,7 +139,7 @@ const ArtworkUpload = () => {
         <FilterDropdown
           label='작품 카테고리'
           placeholder='카테고리 선택'
-          options={ARTWORK_FIELDS_NOT_INCLUDED_ALL.map((field) => field.name)}
+          options={ARTWORK_FIELDS.map((field) => field.name)}
           selected={selectedArtworkField}
           onChange={(value) => handleArtworkFieldClick(value)}
           isInvalid={!!errors.selectedArtworkFieldError}

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -1,0 +1,5 @@
+const ArtworkUpload = () => {
+  return <div>ArtworkUpload</div>;
+};
+
+export default ArtworkUpload;

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -122,11 +122,16 @@ const ArtworkUpload = () => {
   const isFormValid =
     artworkTitle && selectedArtworkField && uploadedImage && !isSubmitting;
 
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleRequiredFieldsNotFilledOut = () => {
+    validateArtworkUploadForm();
+    handleScrollToTop();
+  };
+
   const handleArtworkUpload = () => {
-    if (!validateArtworkUploadForm()) {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-      return;
-    }
     setIsSubmitting(true);
 
     // TODO: 업로드 성공 시, 작성한 글 상세 페이지로 이동
@@ -261,6 +266,7 @@ const ArtworkUpload = () => {
           </OvalButton>
         ) : (
           <button
+            onClick={handleRequiredFieldsNotFilledOut}
             className='button-s text-gray-300 bg-gray-700 px-[28px] leading-[50px]
             flex items-center justify-center rounded-full gap-[10px]
             transition-all duration-300 ease-in-out active:scale-95 hover:opacity-70 hover:cursor-not-allowed'

--- a/src/components/ArtworkPage/ArtworkFilter.tsx
+++ b/src/components/ArtworkPage/ArtworkFilter.tsx
@@ -1,3 +1,6 @@
+import { ArtworkField } from '@/types';
+
+import ARTWORK_FIELDS from '../../constants/artworkFields';
 import OvalButton from '../Button/OvalButton';
 import DefaultCarousel from '../Carousel/DefaultCarousel';
 import FilterDropdown from '../FilterDropdown';
@@ -10,23 +13,6 @@ interface ArtworkFilterProps {
   setCurrentPage: (value: number | ((prev: number) => number)) => void;
 }
 
-interface ArtworkField {
-  name: string;
-  value: string;
-}
-
-const ARTWORK_FIELDS = [
-  { name: '전체', value: 'ALL' },
-  { name: '회화', value: 'PAINTING' },
-  { name: '공예/조각', value: 'CRAFTSCULPTURE' },
-  { name: '드로잉', value: 'DRAWING' },
-  { name: '판화', value: 'PRINTMAKING' },
-  { name: '서예', value: 'CALLIGRAPHY' },
-  { name: '일러스트', value: 'ILLUSTRATION' },
-  { name: '디지털아트', value: 'DIGITALART' },
-  { name: '사진', value: 'PHOTOGRAPHY' },
-  { name: '기타', value: 'OTHERS' },
-];
 const FILTER_OPTIONS = ['최신순', '인기순', '조회순'];
 
 const ArtworkFilter = ({

--- a/src/components/ArtworkPage/ArtworkFilter.tsx
+++ b/src/components/ArtworkPage/ArtworkFilter.tsx
@@ -77,6 +77,7 @@ const ArtworkFilter = ({
           options={FILTER_OPTIONS}
           selected={selectedFilter}
           onChange={handleFilterChange}
+          className='w-[149px]'
         />
       </div>
     </>

--- a/src/components/ArtworkPage/ArtworkFilter.tsx
+++ b/src/components/ArtworkPage/ArtworkFilter.tsx
@@ -13,6 +13,11 @@ interface ArtworkFilterProps {
   setCurrentPage: (value: number | ((prev: number) => number)) => void;
 }
 
+const ARTWORK_FIELDS_WITH_ALL_OPTION = [
+  { name: '전체', value: 'ALL' },
+  ...ARTWORK_FIELDS,
+];
+
 const FILTER_OPTIONS = ['최신순', '인기순', '조회순'];
 
 const ArtworkFilter = ({
@@ -23,8 +28,9 @@ const ArtworkFilter = ({
   setCurrentPage,
 }: ArtworkFilterProps) => {
   const selectedArtworkFieldName =
-    ARTWORK_FIELDS.find((field) => field.value === selectedArtworkField)
-      ?.name || '전체';
+    ARTWORK_FIELDS_WITH_ALL_OPTION.find(
+      (field) => field.value === selectedArtworkField,
+    )?.name || '전체';
 
   const handleArtworkFieldClick = (artworkField: string) => {
     setSelectedArtworkField(artworkField);
@@ -39,7 +45,7 @@ const ArtworkFilter = ({
     <>
       <div className='flex w-full justify-between items-end pb-[59px] overflow-x-auto'>
         <DefaultCarousel
-          slides={ARTWORK_FIELDS}
+          slides={ARTWORK_FIELDS_WITH_ALL_OPTION}
           renderSlide={(artworkField: ArtworkField) => (
             <OvalButton
               key={artworkField.value}

--- a/src/components/Button/OvalButton.tsx
+++ b/src/components/Button/OvalButton.tsx
@@ -29,7 +29,7 @@ const OvalButton = ({
 
   const buttonSizeClasses = {
     m: 'px-[46px] leading-[69px]',
-    s: 'px-[20px] leading-[50px]',
+    s: 'px-[28px] leading-[50px]',
   };
 
   return (

--- a/src/components/Button/OvalButton.tsx
+++ b/src/components/Button/OvalButton.tsx
@@ -3,6 +3,7 @@ import { OvalButtonProps } from '@/types';
 const OvalButton = ({
   variant = 'primary',
   buttonSize,
+  className,
   children,
 
   onClick,
@@ -27,8 +28,8 @@ const OvalButton = ({
   };
 
   const buttonSizeClasses = {
-    m: 'h-[69px] px-[46px] py-[17px]',
-    s: 'h-[50px] px-[34px] py-[20px]',
+    m: 'leading-[69px]',
+    s: 'leading-[50px]',
   };
 
   return (
@@ -42,6 +43,7 @@ const OvalButton = ({
         ${hoverBgColorClasses[variant]}
         ${textColorClasses[variant]}
         ${buttonSizeClasses[buttonSize]}
+        ${className}
       `}
     >
       {buttonSize === 'm' ? (

--- a/src/components/Button/OvalButton.tsx
+++ b/src/components/Button/OvalButton.tsx
@@ -7,6 +7,7 @@ const OvalButton = ({
   onClick,
 
   className,
+  disabled,
   ariaLabel,
 }: OvalButtonProps) => {
   const bgColorClasses = {
@@ -35,6 +36,7 @@ const OvalButton = ({
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
       aria-label={ariaLabel}
       className={`
         flex items-center justify-center rounded-full gap-[10px]

--- a/src/components/Button/OvalButton.tsx
+++ b/src/components/Button/OvalButton.tsx
@@ -3,10 +3,10 @@ import { OvalButtonProps } from '@/types';
 const OvalButton = ({
   variant = 'primary',
   buttonSize,
-  className,
   children,
-
   onClick,
+
+  className,
   ariaLabel,
 }: OvalButtonProps) => {
   const bgColorClasses = {
@@ -28,8 +28,8 @@ const OvalButton = ({
   };
 
   const buttonSizeClasses = {
-    m: 'leading-[69px]',
-    s: 'leading-[50px]',
+    m: 'px-[46px] leading-[69px]',
+    s: 'px-[20px] leading-[50px]',
   };
 
   return (
@@ -38,7 +38,7 @@ const OvalButton = ({
       aria-label={ariaLabel}
       className={`
         flex items-center justify-center rounded-full gap-[10px]
-        transition-all duration-300 ease-in-out active:scale-95 w-full
+        transition-all duration-300 ease-in-out active:scale-95
         ${bgColorClasses[variant]}
         ${hoverBgColorClasses[variant]}
         ${textColorClasses[variant]}

--- a/src/components/FilterDropdown/index.tsx
+++ b/src/components/FilterDropdown/index.tsx
@@ -13,6 +13,8 @@ interface FilterDropdownProps {
 
   label?: string;
   placeholder?: string;
+  isInvalid?: boolean;
+  errorMessage?: string;
   className?: string;
 }
 
@@ -22,6 +24,8 @@ const FilterDropdown = ({
   onChange,
   label,
   placeholder,
+  isInvalid = false,
+  errorMessage,
   className,
 }: FilterDropdownProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -90,6 +94,19 @@ const FilterDropdown = ({
           </ul>
         </div>
       )}
+
+      <div className='flex items-center mt-[3px] h-[26px]'>
+        {isInvalid && errorMessage && (
+          <>
+            <Icon
+              name='CheckCircleFilled'
+              size='s'
+              className='text-system-error mr-2'
+            />
+            <p className='button-s text-system-error'>{errorMessage}</p>
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/FilterDropdown/index.tsx
+++ b/src/components/FilterDropdown/index.tsx
@@ -99,7 +99,7 @@ const FilterDropdown = ({
         {isInvalid && errorMessage && (
           <>
             <Icon
-              name='CheckCircleFilled'
+              name='AlertCircle'
               size='s'
               className='text-system-error mr-2'
             />

--- a/src/components/FilterDropdown/index.tsx
+++ b/src/components/FilterDropdown/index.tsx
@@ -10,12 +10,19 @@ interface FilterDropdownProps {
   options: string[];
   selected: string;
   onChange: (value: string) => void;
+
+  label?: string;
+  placeholder?: string;
+  className?: string;
 }
 
 const FilterDropdown = ({
   options,
   selected,
   onChange,
+  label,
+  placeholder,
+  className,
 }: FilterDropdownProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -29,16 +36,29 @@ const FilterDropdown = ({
   };
 
   return (
-    <div className='body2 relative inline-block text-left' ref={dropdownRef}>
+    <div
+      className={`body2 relative inline-block text-left ${className}`}
+      ref={dropdownRef}
+    >
+      {label && (
+        <label className='placeholder block pb-[7px] text-gray-400'>
+          {label}
+        </label>
+      )}
+
       <button
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-        aria-label={`Currently selected filter: ${selected}`}
+        aria-label={`Currently selected filter: ${selected || placeholder}`}
         aria-expanded={isDropdownOpen}
-        className='flex items-center justify-between w-[149px] h-[44px] px-[23px] py-[10px]
+        className={`flex items-center justify-between px-[20px] leading-[60px]
         text-white bg-gray-900 rounded-[5px] gap-[36px] shadow-sm
-        hover:bg-gray-800 focus:outline-none'
+        hover:bg-gray-800 focus:outline-none
+        ${className}
+        `}
       >
-        {selected}
+        {selected || (
+          <span className='placeholder text-gray-700'>{placeholder}</span>
+        )}
         <span className='text-gray-700'>
           {isDropdownOpen ? (
             <Icon name='Dropup' size='m' />
@@ -50,7 +70,7 @@ const FilterDropdown = ({
 
       {isDropdownOpen && (
         <div
-          className='absolute z-10 w-full mt-3 bg-gray-900 rounded-[5px] shadow-lg'
+          className={`absolute z-10 mt-3 bg-gray-900 rounded-[5px] shadow-lg ${className}`}
           role='menu'
         >
           <ul className='py-1'>
@@ -59,7 +79,7 @@ const FilterDropdown = ({
                 key={index}
                 onClick={() => handleOptionSelect(option)}
                 aria-current={option === selected ? 'true' : undefined}
-                className={`block w-[149px] h-[44px] px-[23px] py-[10px]
+                className={`block px-[23px] leading-[60px]
                   text-gray-400 cursor-pointer
                   ${option === selected && isDropdownOpen ? 'text-white' : 'text-gray-400'}
                   hover:bg-background-overlay`}

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Input } from '@nextui-org/react';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 
 import Icon from '../Icon/Icon';
 
@@ -11,7 +11,7 @@ interface BasicInputProps {
   placeholder?: string;
 
   value: string;
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 
   showClear?: boolean;
   onClear?: () => void;
@@ -41,6 +41,7 @@ const BasicInput = ({
   successMessage,
 }: BasicInputProps) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const togglePasswordVisibility = () =>
     setIsPasswordVisible(!isPasswordVisible);
@@ -53,53 +54,102 @@ const BasicInput = ({
         ? 'text-system-error'
         : 'text-white';
 
+  const handleInputChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    onChange(e);
+    if (type === 'textarea' && textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  };
+
   return (
     <div>
-      <Input
-        type={showEyeIcon && isPasswordVisible ? 'text' : type || 'text'}
-        label={label}
-        labelPlacement='outside'
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}
-        onClear={showClear ? onClear : undefined}
-        isInvalid={false}
-        minLength={minLength}
-        maxLength={maxLength}
-        endContent={
-          <>
-            {showEyeIcon && (
-              <button
-                type='button'
-                aria-label='toggle password visibility'
-                onClick={togglePasswordVisibility}
-                disabled={value === ''}
-                className='px-[10px]'
-              >
-                <Icon
-                  name={isPasswordVisible ? 'Eye' : 'EyeOff'}
-                  size='m'
-                  className={`text-gray-200 ${value === '' ? 'text-gray-800' : ''}`}
-                />
-              </button>
-            )}
+      {type === 'textarea' ? (
+        <>
+          <label className='placeholder block pb-[7px] text-gray-400'>
+            {label}
+          </label>
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={handleInputChange}
+            placeholder={placeholder}
+            maxLength={maxLength}
+            className={`placeholder bg-gray-900 rounded-md w-full h-auto resize-none
+              ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
+              ${isInvalid ? 'border border-system-error' : 'border border-transparent'} 
+              focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
+              `}
+            style={{
+              minHeight: '256px',
+              padding: '20px',
+            }}
+          />
+          {showTextLength && maxLength && (
+            <div className='flex justify-end items-center px-[10px]'>
+              <span className={`placeholder ${textLengthColor}`}>
+                {currentTextLength}
+              </span>
+              <span className='placeholder text-gray-700'>/{maxLength}</span>
+            </div>
+          )}
+        </>
+      ) : (
+        <Input
+          type={showEyeIcon && isPasswordVisible ? 'text' : type || 'text'}
+          label={label}
+          labelPlacement='outside'
+          placeholder={placeholder}
+          value={value}
+          onChange={onChange}
+          onClear={showClear ? onClear : undefined}
+          isInvalid={false}
+          minLength={minLength}
+          maxLength={maxLength}
+          endContent={
+            <>
+              {showEyeIcon && (
+                <button
+                  type='button'
+                  aria-label='toggle password visibility'
+                  onClick={togglePasswordVisibility}
+                  disabled={value === ''}
+                  className='px-[10px]'
+                >
+                  <Icon
+                    name={isPasswordVisible ? 'Eye' : 'EyeOff'}
+                    size='m'
+                    className={`text-gray-200 ${value === '' ? 'text-gray-800' : ''}`}
+                  />
+                </button>
+              )}
 
-            {showTextLength && maxLength && (
-              <div className='flex items-center px-[10px]'>
-                <span className={`placeholder ${textLengthColor}`}>
-                  {currentTextLength}
-                </span>
-                <span className='placeholder text-gray-700'>/{maxLength}</span>
-              </div>
-            )}
-          </>
-        }
-        classNames={{
-          label: ['!placeholder', '!top-5', '!text-gray-400'],
-          input: ['!placeholder', 'text-gray-700', 'px-[10px]'],
-          inputWrapper: ['bg-gray-900', 'rounded-md', 'h-15', 'leading-[60px]'],
-        }}
-      />
+              {showTextLength && maxLength && (
+                <div className='flex items-center px-[10px]'>
+                  <span className={`placeholder ${textLengthColor}`}>
+                    {currentTextLength}
+                  </span>
+                  <span className='placeholder text-gray-700'>
+                    /{maxLength}
+                  </span>
+                </div>
+              )}
+            </>
+          }
+          classNames={{
+            label: ['!placeholder', '!top-5', '!text-gray-400'],
+            input: ['!placeholder', 'placeholder:text-gray-700', 'px-[10px]'],
+            inputWrapper: [
+              'bg-gray-900',
+              'rounded-md',
+              'h-15',
+              'leading-[60px]',
+            ],
+          }}
+        />
+      )}
       <div className='flex items-center mt-[3px] h-[26px]'>
         {isInvalid && errorMessage ? (
           <>

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Input } from '@nextui-org/react';
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 import Icon from '../Icon/Icon';
 
@@ -11,7 +11,7 @@ interface BasicInputProps {
   placeholder?: string;
 
   value: string;
-  onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 
   showClear?: boolean;
   onClear?: () => void;
@@ -41,7 +41,6 @@ const BasicInput = ({
   successMessage,
 }: BasicInputProps) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const togglePasswordVisibility = () =>
     setIsPasswordVisible(!isPasswordVisible);
@@ -54,103 +53,54 @@ const BasicInput = ({
         ? 'text-system-error'
         : 'text-white';
 
-  const handleInputChange = (
-    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    onChange(e);
-    if (type === 'textarea' && textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-    }
-  };
-
   return (
-    <div>
-      {type === 'textarea' ? (
-        <>
-          <label className='placeholder block pb-[7px] text-gray-400'>
-            {label}
-          </label>
-          <div className='relative w-full h-auto'>
-            <textarea
-              ref={textareaRef}
-              value={value}
-              onChange={handleInputChange}
-              placeholder={placeholder}
-              maxLength={maxLength}
-              className={`placeholder bg-gray-900 rounded-md w-full h-auto resize-none
-                ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
-                focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
-                `}
-              style={{
-                minHeight: '256px',
-                padding: '20px',
-              }}
-            />
+    <>
+      <Input
+        type={showEyeIcon && isPasswordVisible ? 'text' : type || 'text'}
+        label={label}
+        labelPlacement='outside'
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+        onClear={showClear ? onClear : undefined}
+        isInvalid={false}
+        minLength={minLength}
+        maxLength={maxLength}
+        endContent={
+          <>
+            {showEyeIcon && (
+              <button
+                type='button'
+                aria-label='toggle password visibility'
+                onClick={togglePasswordVisibility}
+                disabled={value === ''}
+                className='px-[10px]'
+              >
+                <Icon
+                  name={isPasswordVisible ? 'Eye' : 'EyeOff'}
+                  size='m'
+                  className={`text-gray-200 ${value === '' ? 'text-gray-800' : ''}`}
+                />
+              </button>
+            )}
+
             {showTextLength && maxLength && (
-              <div className='absolute bottom-[20px] right-[20px]'>
+              <div className='flex items-center px-[10px]'>
                 <span className={`placeholder ${textLengthColor}`}>
                   {currentTextLength}
                 </span>
                 <span className='placeholder text-gray-700'>/{maxLength}</span>
               </div>
             )}
-          </div>
-        </>
-      ) : (
-        <Input
-          type={showEyeIcon && isPasswordVisible ? 'text' : type || 'text'}
-          label={label}
-          labelPlacement='outside'
-          placeholder={placeholder}
-          value={value}
-          onChange={onChange}
-          onClear={showClear ? onClear : undefined}
-          isInvalid={false}
-          minLength={minLength}
-          maxLength={maxLength}
-          endContent={
-            <>
-              {showEyeIcon && (
-                <button
-                  type='button'
-                  aria-label='toggle password visibility'
-                  onClick={togglePasswordVisibility}
-                  disabled={value === ''}
-                  className='px-[10px]'
-                >
-                  <Icon
-                    name={isPasswordVisible ? 'Eye' : 'EyeOff'}
-                    size='m'
-                    className={`text-gray-200 ${value === '' ? 'text-gray-800' : ''}`}
-                  />
-                </button>
-              )}
+          </>
+        }
+        classNames={{
+          label: ['!placeholder', '!top-5', '!text-gray-400'],
+          input: ['!placeholder', 'placeholder:text-gray-700', 'px-[10px]'],
+          inputWrapper: ['bg-gray-900', 'rounded-md', 'h-15', 'leading-[60px]'],
+        }}
+      />
 
-              {showTextLength && maxLength && (
-                <div className='flex items-center px-[10px]'>
-                  <span className={`placeholder ${textLengthColor}`}>
-                    {currentTextLength}
-                  </span>
-                  <span className='placeholder text-gray-700'>
-                    /{maxLength}
-                  </span>
-                </div>
-              )}
-            </>
-          }
-          classNames={{
-            label: ['!placeholder', '!top-5', '!text-gray-400'],
-            input: ['!placeholder', 'placeholder:text-gray-700', 'px-[10px]'],
-            inputWrapper: [
-              'bg-gray-900',
-              'rounded-md',
-              'h-15',
-              'leading-[60px]',
-            ],
-          }}
-        />
-      )}
       <div className='flex items-center mt-[3px] h-[26px]'>
         {isInvalid && errorMessage ? (
           <>
@@ -174,7 +124,7 @@ const BasicInput = ({
           )
         )}
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -74,6 +74,7 @@ const BasicInput = ({
                 aria-label='toggle password visibility'
                 onClick={togglePasswordVisibility}
                 disabled={value === ''}
+                className='px-[10px]'
               >
                 <Icon
                   name={isPasswordVisible ? 'Eye' : 'EyeOff'}
@@ -84,7 +85,7 @@ const BasicInput = ({
             )}
 
             {showTextLength && maxLength && (
-              <div className='flex items-center'>
+              <div className='flex items-center px-[10px]'>
                 <span className={`placeholder ${textLengthColor}`}>
                   {currentTextLength}
                 </span>
@@ -94,9 +95,9 @@ const BasicInput = ({
           </>
         }
         classNames={{
-          label: ['custom-label', 'top-5', '!text-gray-400'],
-          input: 'placeholder:text-gray-700',
-          inputWrapper: ['bg-gray-900', 'rounded-md', 'h-15'],
+          label: ['!placeholder', '!top-5', '!text-gray-400'],
+          input: ['!placeholder', 'text-gray-700', 'px-[10px]'],
+          inputWrapper: ['bg-gray-900', 'rounded-md', 'h-15', 'leading-[60px]'],
         }}
       />
       <div className='flex items-center mt-[3px] h-[26px]'>

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -71,30 +71,32 @@ const BasicInput = ({
           <label className='placeholder block pb-[7px] text-gray-400'>
             {label}
           </label>
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={handleInputChange}
-            placeholder={placeholder}
-            maxLength={maxLength}
-            className={`placeholder bg-gray-900 rounded-md w-full h-auto resize-none
-              ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
-              ${isInvalid ? 'border border-system-error' : 'border border-transparent'} 
-              focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
-              `}
-            style={{
-              minHeight: '256px',
-              padding: '20px',
-            }}
-          />
-          {showTextLength && maxLength && (
-            <div className='flex justify-end items-center px-[10px]'>
-              <span className={`placeholder ${textLengthColor}`}>
-                {currentTextLength}
-              </span>
-              <span className='placeholder text-gray-700'>/{maxLength}</span>
-            </div>
-          )}
+          <div className='relative w-full h-auto'>
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={handleInputChange}
+              placeholder={placeholder}
+              maxLength={maxLength}
+              className={`placeholder bg-gray-900 rounded-md w-full h-auto resize-none
+      ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
+      ${isInvalid ? 'border border-system-error' : 'border border-transparent'} 
+      focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
+    `}
+              style={{
+                minHeight: '256px',
+                padding: '20px',
+              }}
+            />
+            {showTextLength && maxLength && (
+              <div className='absolute bottom-[20px] right-[20px]'>
+                <span className={`placeholder ${textLengthColor}`}>
+                  {currentTextLength}
+                </span>
+                <span className='placeholder text-gray-700'>/{maxLength}</span>
+              </div>
+            )}
+          </div>
         </>
       ) : (
         <Input

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -155,7 +155,7 @@ const BasicInput = ({
         {isInvalid && errorMessage ? (
           <>
             <Icon
-              name='CheckCircleFilled'
+              name='AlertCircle'
               size='s'
               className='text-system-error mr-2'
             />
@@ -165,7 +165,7 @@ const BasicInput = ({
           successMessage && (
             <>
               <Icon
-                name='AlertCircle'
+                name='CheckCircleFilled'
                 size='s'
                 className='text-gray-400 mr-2'
               />

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -79,10 +79,10 @@ const BasicInput = ({
               placeholder={placeholder}
               maxLength={maxLength}
               className={`placeholder bg-gray-900 rounded-md w-full h-auto resize-none
-      ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
-      ${isInvalid ? 'border border-system-error' : 'border border-transparent'} 
-      focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
-    `}
+                ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
+                ${isInvalid ? 'border border-system-error' : 'border border-transparent'}
+                focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
+                `}
               style={{
                 minHeight: '256px',
                 padding: '20px',

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -80,7 +80,6 @@ const BasicInput = ({
               maxLength={maxLength}
               className={`placeholder bg-gray-900 rounded-md w-full h-auto resize-none
                 ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
-                ${isInvalid ? 'border border-system-error' : 'border border-transparent'}
                 focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
                 `}
               style={{

--- a/src/components/Input/EmailInput.tsx
+++ b/src/components/Input/EmailInput.tsx
@@ -45,7 +45,7 @@ const EmailInput = ({ mode }: EmailInputProps) => {
         placeholder='이메일을 입력해주세요.'
         isInvalid={false}
         classNames={{
-          label: 'custom-label',
+          label: 'placeholder',
           input: 'placeholder:text-gray-700',
           inputWrapper: ['bg-gray-900', 'rounded-md'],
         }}

--- a/src/components/Input/NicknameInput.tsx
+++ b/src/components/Input/NicknameInput.tsx
@@ -48,7 +48,7 @@ const NicknameInput = () => {
         placeholder='닉네임을 입력해주세요.'
         maxLength={MAX_NICKNAME_LENGTH}
         classNames={{
-          label: 'custom-label',
+          label: 'placeholder',
           input: 'placeholder:text-gray-700',
           inputWrapper: ['bg-gray-900', 'rounded-md'],
         }}

--- a/src/components/Input/PasswordInput.tsx
+++ b/src/components/Input/PasswordInput.tsx
@@ -45,7 +45,7 @@ const PasswordInput = ({ mode }: PasswordnputProps) => {
         labelPlacement='outside'
         placeholder='비밀번호를 입력해주세요.'
         classNames={{
-          label: 'custom-label',
+          label: 'placeholder',
           input: 'placeholder:text-gray-700',
           inputWrapper: ['bg-gray-900', 'rounded-md'],
         }}

--- a/src/components/Input/Textarea.tsx
+++ b/src/components/Input/Textarea.tsx
@@ -1,0 +1,77 @@
+import { ChangeEvent, useRef } from 'react';
+
+interface TextareaProps {
+  label?: string;
+  placeholder?: string;
+
+  value: string;
+  onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+
+  showTextLength?: boolean;
+  isInvalid?: boolean;
+  maxLength?: number;
+  errorMessage?: string;
+}
+
+const Textarea = ({
+  label,
+  placeholder,
+  value,
+  onChange,
+  maxLength,
+  showTextLength,
+}: TextareaProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const currentTextLength = value.length;
+  const textLengthColor =
+    currentTextLength === 0
+      ? 'text-gray-700'
+      : maxLength && currentTextLength > maxLength
+        ? 'text-system-error'
+        : 'text-white';
+
+  const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    onChange(e);
+
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  };
+
+  return (
+    <>
+      <label className='placeholder block pb-[7px] text-gray-400'>
+        {label}
+      </label>
+      <div className='relative w-full h-auto'>
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={handleInputChange}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          className={`placeholder bg-gray-900 rounded-md w-full h-auto resize-none
+                ${value.length ? 'text-white' : 'placeholder:text-gray-700'}
+                focus:outline-none focus:ring-0 bg-gray-900 hover:bg-[#18181b] focus:bg-[#18181b]
+                `}
+          style={{
+            minHeight: '256px',
+            padding: '20px',
+          }}
+        />
+        {showTextLength && maxLength && (
+          <div className='absolute bottom-[20px] right-[20px]'>
+            <span className={`placeholder ${textLengthColor}`}>
+              {currentTextLength}
+            </span>
+            <span className='placeholder text-gray-700'>/{maxLength}</span>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default Textarea;

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -102,7 +102,6 @@ const Navbar = () => {
                     variant='primary'
                     buttonSize='s'
                     onClick={moveToArtworkUpload}
-                    className='w-[124px]'
                   >
                     <p className='placholder'>작품 업로드</p>
                   </OvalButton>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -102,6 +102,7 @@ const Navbar = () => {
                     variant='primary'
                     buttonSize='s'
                     onClick={moveToArtworkUpload}
+                    className='w-[124px]'
                   >
                     <p className='placholder'>작품 업로드</p>
                   </OvalButton>

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -101,11 +101,9 @@ const Navbar = () => {
                   <OvalButton
                     variant='primary'
                     buttonSize='s'
-                    onClick={moveToArtworkList}
+                    onClick={moveToArtworkUpload}
                   >
-                    <p className='placholder' onClick={moveToArtworkUpload}>
-                      작품 업로드
-                    </p>
+                    <p className='placholder'>작품 업로드</p>
                   </OvalButton>
                 </>
               ) : (

--- a/src/constants/artworkFields.ts
+++ b/src/constants/artworkFields.ts
@@ -1,5 +1,4 @@
 const ARTWORK_FIELDS = [
-  { name: '전체', value: 'ALL' },
   { name: '회화', value: 'PAINTING' },
   { name: '공예/조각', value: 'CRAFTSCULPTURE' },
   { name: '드로잉', value: 'DRAWING' },

--- a/src/constants/artworkFields.ts
+++ b/src/constants/artworkFields.ts
@@ -1,0 +1,14 @@
+const ARTWORK_FIELDS = [
+  { name: '전체', value: 'ALL' },
+  { name: '회화', value: 'PAINTING' },
+  { name: '공예/조각', value: 'CRAFTSCULPTURE' },
+  { name: '드로잉', value: 'DRAWING' },
+  { name: '판화', value: 'PRINTMAKING' },
+  { name: '서예', value: 'CALLIGRAPHY' },
+  { name: '일러스트', value: 'ILLUSTRATION' },
+  { name: '디지털아트', value: 'DIGITALART' },
+  { name: '사진', value: 'PHOTOGRAPHY' },
+  { name: '기타', value: 'OTHERS' },
+];
+
+export default ARTWORK_FIELDS;

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -3,6 +3,7 @@ const ROUTE = {
   signIn: '/auth/sign-in',
   signUp: '/auth/sign-up',
   artworkList: '/artwork/list',
+  artworkUpload: '/artwork/upload',
 };
 
 export default ROUTE;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -51,8 +51,7 @@
   }
 
   .body2,
-  .placeholder,
-  .custom-label {
+  .placeholder {
     font-size: 1rem; /* 16px */
   }
 
@@ -72,7 +71,6 @@
     font-weight: 600; /* SemiBold */
   }
 
-  .custom-label,
   .subtitle2,
   .placeholder,
   .button-l,

--- a/src/types/artwork.ts
+++ b/src/types/artwork.ts
@@ -24,3 +24,8 @@ export interface ArtworkListResponse {
   data: ArtworkInfoType[];
   page: PaginationType;
 }
+
+export interface ArtworkField {
+  name: string;
+  value: string;
+}

--- a/src/types/buttons/OvalButtonProps.ts
+++ b/src/types/buttons/OvalButtonProps.ts
@@ -6,4 +6,5 @@ export interface OvalButtonProps
     'disabled' | 'loading' | 'icon' | 'iconPosition' | 'type'
   > {
   buttonSize: 's' | 'm';
+  className?: string;
 }

--- a/src/types/buttons/OvalButtonProps.ts
+++ b/src/types/buttons/OvalButtonProps.ts
@@ -1,10 +1,7 @@
 import { BaseButtonProps } from './BaseButtonProps';
 
 export interface OvalButtonProps
-  extends Omit<
-    BaseButtonProps,
-    'disabled' | 'loading' | 'icon' | 'iconPosition' | 'type'
-  > {
+  extends Omit<BaseButtonProps, 'loading' | 'icon' | 'iconPosition' | 'type'> {
   buttonSize: 's' | 'm';
   className?: string;
 }


### PR DESCRIPTION
## 📝 작업 내용

**1. 디자인 시스템 적용**
- [x]  `OvalButton`
    - [x]  사진 업로드 (왼쪽에 `UploadShare` 아이콘 추가)
    - [x]  업로드 버튼 (제출 목적)
- [x]  `FilterDropdown`
    - [x]  전체공개, 비공개 (Default: 전체공개)
    - [x]  회화, 공예/조각, 드로잉, 판화, 서예, 일러스트, 디지털아트, 사진, 기타 (Default: X)
- [x]  `Input`
    - [x]  작품 제목 (endContent: TextLength - 50자)
    - [x]  작품 설명
        - [x]  endContent: TextLength - 1000자
        - [x]  작성한 내용이 해당 height 범위를 넘어갈 경우, 텍스트 크기만큼 height 범위가 늘어나도록 구현
    - [x]  `placeholder` 추가

**2. 작품 업로드 페이지에서만 사용하는 UI 구축**
- [x]  작품 이미지 업로드 UI
    - [x]  테두리 점선 처리
    - [x]  이미지 변경 버튼 (`Image` 아이콘 추가)
- [x]  필수 항목(**제목, 카테고리, 이미지**) 유효성 검사
    - [x]  필수 항목 입력 완료돼야 업로드 버튼이 활성화되도록 처리
    - [x]  Error 색상 메시지: 미작성 시, ‘필수 항목입니다.’ 메시지 보이도록 처리
    - [x]  업로드 버튼이 비활성화(disabled) 상태일 때 누르면 페이지 상단으로 스크롤 올라가도록 처리
- [x]  업로드 버튼 (제출용)
    - [x]  한 번 클릭 시, `disabled` 처리
    - [x]  업로드 `disable` 버튼 만들어야 함 ⇒ 디자인 시스템 버튼 아님 (색상 다름) `*hover:cursor-not-allowed*`
- [x]  CSS 잘 반영됐는지 점검: width, height, 색상, 정렬
- [x]  리팩토링
- [x]  `type`이 'textarea'인지 아닌지에 따라 렌더링이 분기 처리 중 → textarea, input 따로 분리

**3. 모바일 비율에 따른 반응형 적용**


## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/04493aaa-d992-49d3-954e-f1cfa01468ba)

![image](https://github.com/user-attachments/assets/f9e0de6f-9741-4fcf-95eb-71c4930fe182)