### PR TITLE
[TASK-84, TASK-85] feat, style: 상세 페이지 우측 버튼 그룹 및 관련 모달 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query-devtools": "^5.64.1",
     "@types/lodash": "^4.17.13",
     "axios": "^1.7.9",
+    "clipboard": "^2.0.11",
     "embla-carousel": "^8.5.1",
     "embla-carousel-autoplay": "^8.5.1",
     "embla-carousel-react": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       axios:
         specifier: ^1.7.9
         version: 1.7.9
+      clipboard:
+        specifier: ^2.0.11
+        version: 2.0.11
       embla-carousel:
         specifier: ^8.5.1
         version: 8.5.1
@@ -3024,6 +3027,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clipboard@2.0.11:
+    resolution: {integrity: sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3235,6 +3241,9 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  delegate@3.2.0:
+    resolution: {integrity: sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3816,6 +3825,9 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  good-listener@1.2.2:
+    resolution: {integrity: sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4965,6 +4977,9 @@ packages:
   scroll-into-view-if-needed@3.0.10:
     resolution: {integrity: sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==}
 
+  select@1.1.2:
+    resolution: {integrity: sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -5231,6 +5246,9 @@ packages:
   timers-browserify@2.0.12:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
+
+  tiny-emitter@2.1.0:
+    resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -9625,6 +9643,12 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clipboard@2.0.11:
+    dependencies:
+      good-listener: 1.2.2
+      select: 1.1.2
+      tiny-emitter: 2.1.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -9835,6 +9859,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  delegate@3.2.0: {}
 
   dequal@2.0.3: {}
 
@@ -10609,6 +10635,10 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  good-listener@1.2.2:
+    dependencies:
+      delegate: 3.2.0
 
   gopd@1.2.0: {}
 
@@ -11787,6 +11817,8 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 3.1.0
 
+  select@1.1.2: {}
+
   semver@6.3.1: {}
 
   semver@7.6.3: {}
@@ -12123,6 +12155,8 @@ snapshots:
   timers-browserify@2.0.12:
     dependencies:
       setimmediate: 1.0.5
+
+  tiny-emitter@2.1.0: {}
 
   tiny-invariant@1.3.3: {}
 

--- a/src/apis/artwork/deleteArtworkLike.ts
+++ b/src/apis/artwork/deleteArtworkLike.ts
@@ -1,0 +1,39 @@
+import { isAxiosError } from 'axios';
+
+import { ARTWORK } from '@/constants/API';
+import {
+  COMMON_ERROR_MESSAGE,
+  LIKE_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { ErrorResponseType } from '@/types/errorResponse';
+
+import { authorizedClient } from '..';
+
+const deleteArtworkLike = async (postId: number) => {
+  try {
+    const response = await authorizedClient.delete(ARTWORK.artworkLike(postId));
+
+    if (response.status === 204) {
+      return true;
+    } else {
+      throw new Error('좋아요 취소 요청 실패');
+    }
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        console.error(LIKE_ERROR_MESSAGE[code]);
+        throw new Error(LIKE_ERROR_MESSAGE[code]);
+      } else {
+        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+        throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+  }
+};
+
+export default deleteArtworkLike;

--- a/src/apis/artwork/postArtworkLike.ts
+++ b/src/apis/artwork/postArtworkLike.ts
@@ -1,0 +1,41 @@
+import { isAxiosError } from 'axios';
+
+import { ARTWORK } from '@/constants/API';
+import {
+  COMMON_ERROR_MESSAGE,
+  LIKE_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { ErrorResponseType } from '@/types/errorResponse';
+
+import { authorizedClient } from '..';
+
+const postArtworkLike = async (postId: number) => {
+  try {
+    const response = await authorizedClient.post<null>(
+      ARTWORK.artworkLike(postId),
+    );
+
+    if (response.status === 204) {
+      return true;
+    } else {
+      throw new Error('좋아요 요청 실패');
+    }
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        console.error(LIKE_ERROR_MESSAGE[code]);
+        throw new Error(LIKE_ERROR_MESSAGE[code]);
+      } else {
+        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+        throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+  }
+};
+
+export default postArtworkLike;

--- a/src/apis/collection/getAllCollectionList.ts
+++ b/src/apis/collection/getAllCollectionList.ts
@@ -1,0 +1,16 @@
+import { COLLECTION } from '@/constants/API';
+import { CollectionType } from '@/types/collection';
+
+import { authorizedClient } from '..';
+
+const getAllCollectionList = async () => {
+  try {
+    const { data } = await authorizedClient.get<{
+      collections: CollectionType[];
+    }>(COLLECTION.allCollectionsList);
+
+    return data;
+  } catch (error) {}
+};
+
+export default getAllCollectionList;

--- a/src/apis/collection/postCollectionAddArtwork.ts
+++ b/src/apis/collection/postCollectionAddArtwork.ts
@@ -1,0 +1,49 @@
+import { isAxiosError } from 'axios';
+
+import { COLLECTION } from '@/constants/API';
+import {
+  COLLECTION_ADD_ARTWORK_ERROR_MESSAGE,
+  COMMON_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { ErrorResponseType } from '@/types/errorResponse';
+
+import { authorizedClient } from '..';
+
+interface PostCollectionAddArtworkProps {
+  collectionId: number;
+  postId: number;
+}
+
+const postCollectionAddArtwork = async ({
+  collectionId,
+  postId,
+}: PostCollectionAddArtworkProps) => {
+  try {
+    const response = await authorizedClient.post<null>(
+      COLLECTION.collectionAddArtwork(collectionId, postId),
+    );
+
+    if (response.status === 201) {
+      return true;
+    } else {
+      throw new Error('컬랙션 내 작품 추가 요청 실패');
+    }
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        console.error(COLLECTION_ADD_ARTWORK_ERROR_MESSAGE[code]);
+        throw new Error(COLLECTION_ADD_ARTWORK_ERROR_MESSAGE[code]);
+      } else {
+        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+        throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+  }
+};
+
+export default postCollectionAddArtwork;

--- a/src/apis/collection/postCreateCollection.ts
+++ b/src/apis/collection/postCreateCollection.ts
@@ -1,0 +1,14 @@
+import { COLLECTION } from '@/constants/API';
+
+import { authorizedClient } from '..';
+
+const postCreateCollection = async (name: string, isPrivate: boolean) => {
+  const response = await authorizedClient.post(COLLECTION.collection, {
+    name,
+    status: isPrivate ? 'PRIVATE' : 'PUBLIC',
+  });
+
+  return response.status === 201;
+};
+
+export default postCreateCollection;

--- a/src/apis/collection/postCreateCollection.ts
+++ b/src/apis/collection/postCreateCollection.ts
@@ -2,7 +2,15 @@ import { COLLECTION } from '@/constants/API';
 
 import { authorizedClient } from '..';
 
-const postCreateCollection = async (name: string, isPrivate: boolean) => {
+export interface PostCreateColleactionProps {
+  name: string;
+  isPrivate: boolean;
+}
+
+const postCreateCollection = async ({
+  name,
+  isPrivate,
+}: PostCreateColleactionProps) => {
   const response = await authorizedClient.post(COLLECTION.collection, {
     name,
     status: isPrivate ? 'PRIVATE' : 'PUBLIC',

--- a/src/components/ArtworkDetailPage/ButtonGroup.tsx
+++ b/src/components/ArtworkDetailPage/ButtonGroup.tsx
@@ -16,7 +16,13 @@ interface ButtonGroupProps {
 }
 
 const ButtonGroup = ({
-  socialInfo: { postId, likeCount: initialLikeCount, isLiked: initialIsLiked },
+  socialInfo: {
+    postId,
+    nickname,
+    title,
+    likeCount: initialLikeCount,
+    isLiked: initialIsLiked,
+  },
 }: ButtonGroupProps) => {
   const { openModal } = useStore(modalStore);
   const [blockButton, setBlockButton] = useState(false);
@@ -41,7 +47,7 @@ const ButtonGroup = ({
   const openShareModal = () => {
     openModal({
       modalSize: 'md',
-      contents: <ShareModal />,
+      contents: <ShareModal nickname={nickname} title={title} />,
     });
   };
 

--- a/src/components/ArtworkDetailPage/ButtonGroup.tsx
+++ b/src/components/ArtworkDetailPage/ButtonGroup.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useStore } from 'zustand';
+
+import Icon from '@/components/Icon/Icon';
+import CollectionModal from '@/components/Modal/CollectionModal';
+import useToggleLike from '@/hooks/serverStateHooks/useToggleLike';
+import modalStore from '@/stores/modalStore';
+import { ArtworkPostSocialInfoType } from '@/types';
+
+import ShareModal from '../Modal/ShareModal';
+
+interface ButtonGroupProps {
+  socialInfo: ArtworkPostSocialInfoType;
+}
+
+const ButtonGroup = ({
+  socialInfo: { postId, likeCount: initialLikeCount, isLiked: initialIsLiked },
+}: ButtonGroupProps) => {
+  const { openModal } = useStore(modalStore);
+  const [blockButton, setBlockButton] = useState(false);
+
+  const {
+    mutate: toggleLike,
+    setLikeStatus,
+    isLiked,
+    likeCount,
+  } = useToggleLike({
+    isLiked: initialIsLiked,
+    likeCount: initialLikeCount,
+  });
+
+  const openCollectionModal = () => {
+    openModal({
+      modalSize: 'lg',
+      contents: <CollectionModal />,
+    });
+  };
+
+  const openShareModal = () => {
+    openModal({
+      modalSize: 'md',
+      contents: <ShareModal />,
+    });
+  };
+
+  const handleClickLikeToggle = () => {
+    setBlockButton(true);
+    toggleLike(postId);
+    setBlockButton(false);
+  };
+
+  useEffect(() => {
+    setLikeStatus({
+      isLiked: initialIsLiked,
+      likeCount: initialLikeCount,
+    });
+  }, [initialLikeCount, initialIsLiked]);
+
+  return (
+    <div className='tablet:absolute top-0 left-full tablet:w-[77px] w-content tablet:h-full tablet:ml-[30px] button-s text-center'>
+      <div className='sticky flex tablet:flex-col gap-[40px] top-[100px]'>
+        <div className='flex flex-col items-center gap-[10px]'>
+          <button
+            className='flex flex-col justify-center items-center tablet:gap-[3px] tablet:w-full w-[57px] rounded-full bg-gray-800 aspect-square active:bg-[#3E3B43]'
+            onClick={handleClickLikeToggle}
+            disabled={blockButton}
+          >
+            <Icon
+              name={isLiked ? 'HeartFilled' : 'Heart'}
+              size='l'
+              className={isLiked ? 'text-[#FF4548]' : 'text-white'}
+            />
+            <p>{likeCount}</p>
+          </button>
+          <p>좋아요</p>
+        </div>
+        <div className='flex flex-col items-center gap-[10px]'>
+          <button
+            className='flex flex-col justify-center items-center tablet:gap-[3px] tablet:w-full w-[57px] rounded-full bg-gray-800 aspect-square active:bg-[#3E3B43]'
+            onClick={openShareModal}
+          >
+            <Icon name='AlternateShare' size='l' />
+          </button>
+          <p>공유하기</p>
+        </div>
+        <div className='flex flex-col items-center gap-[10px]'>
+          <button
+            className='flex flex-col justify-center items-center tablet:gap-[3px] tablet:w-full w-[57px] rounded-full bg-gray-800 aspect-square active:bg-[#3E3B43]'
+            onClick={openCollectionModal}
+          >
+            <Icon name='Bookmark' size='l' />
+          </button>
+          <p>저장하기</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ButtonGroup;

--- a/src/components/Button/SquareButtonL.tsx
+++ b/src/components/Button/SquareButtonL.tsx
@@ -38,11 +38,11 @@ const SquareButtonL = ({
       aria-label={ariaLabel}
       className={`
         button-m flex items-center justify-center rounded-md
-        w-full h-[70px]  py-[20px] gap-[20px]
+        w-full max-h-[70px] h-full py-[20px] gap-[20px]
         transition-all duration-300 ease-in-out active:scale-95
-        ${disabled ? bgColorClasses['secondary'] : bgColorClasses[variant]} 
+        ${disabled ? bgColorClasses['tertiary'] : bgColorClasses[variant]} 
         ${disabled ? 'cursor-not-allowed' : hoverBgColorClasses[variant]}
-        ${disabled ? textColorClasses['secondary'] : textColorClasses[variant]} 
+        ${disabled ? textColorClasses['tertiary'] : textColorClasses[variant]} 
       `}
     >
       {loading && <span>로딩중...</span>}

--- a/src/components/Button/SquareButtonL.tsx
+++ b/src/components/Button/SquareButtonL.tsx
@@ -40,9 +40,9 @@ const SquareButtonL = ({
         button-m flex items-center justify-center rounded-md
         w-full max-h-[70px] h-full py-[20px] gap-[20px]
         transition-all duration-300 ease-in-out active:scale-95
-        ${disabled ? bgColorClasses['tertiary'] : bgColorClasses[variant]} 
+        ${disabled ? bgColorClasses['secondary'] : bgColorClasses[variant]} 
         ${disabled ? 'cursor-not-allowed' : hoverBgColorClasses[variant]}
-        ${disabled ? textColorClasses['tertiary'] : textColorClasses[variant]} 
+        ${disabled ? textColorClasses['secondary'] : textColorClasses[variant]} 
       `}
     >
       {loading && <span>로딩중...</span>}

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -54,7 +54,7 @@ const BasicInput = ({
         : 'text-white';
 
   return (
-    <>
+    <div>
       <Input
         type={showEyeIcon && isPasswordVisible ? 'text' : type || 'text'}
         label={label}
@@ -97,7 +97,7 @@ const BasicInput = ({
         classNames={{
           label: ['!placeholder', '!top-5', '!text-gray-400'],
           input: ['!placeholder', 'placeholder:text-gray-700', 'px-[10px]'],
-          inputWrapper: ['bg-gray-900', 'rounded-md', 'h-15', 'leading-[60px]'],
+          inputWrapper: ['bg-gray-900', 'rounded-md', 'h-[60px]'],
         }}
       />
 
@@ -124,7 +124,7 @@ const BasicInput = ({
           )
         )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/Modal/CollectionModal/CollectionUnit.tsx
+++ b/src/components/Modal/CollectionModal/CollectionUnit.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+
+import DefaultImage from '@/../public/images/defaultArtworkImage.png';
+import Icon from '@/components/Icon/Icon';
+import usePostCollectionAddArtwork from '@/hooks/serverStateHooks/usePostCollectionAddArtwork';
+import { CollectionType } from '@/types/collection';
+
+const CollectionUnit = ({
+  collectionInfo,
+}: {
+  collectionInfo: CollectionType;
+}) => {
+  const { collectionId, collectionImage, name, status } = collectionInfo;
+  const [blockButton, setBlockButton] = useState(false);
+
+  const { mutate: addCollectionArtwork } = usePostCollectionAddArtwork({
+    collectionId,
+  });
+
+  const selectCollectionUnit = () => {
+    setBlockButton(true);
+    addCollectionArtwork();
+    setBlockButton(false);
+  };
+
+  return (
+    <button
+      className='flex tablet:flex-col items-center gap-[8px] tablet:p-0 p-[9px]'
+      onClick={selectCollectionUnit}
+      disabled={blockButton}
+    >
+      <div className='relative tablet:w-full tablet:h-[200px] w-[70px] h-[70px] rounded-[5px] overflow-hidden'>
+        <Image
+          src={collectionImage || DefaultImage}
+          alt={collectionImage ? 'collection-image' : 'default-image'}
+          fill={true}
+        />
+      </div>
+      <div className='flex flex-1 tablet:flex-col justify-between items-center tablet:gap-[3px] gap-[19px]'>
+        <p className='subtitle2 text-white'>{name}</p>
+        <div className='flex items-center gap-0.5 body2 text-gray-500'>
+          <Icon name={status === 'PRIVATE' ? 'Lock' : 'Unlock'} size='s' />
+          <p>{status === 'PRIVATE' ? '비공개' : '전체 공개'}</p>
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default CollectionUnit;

--- a/src/components/Modal/CollectionModal/CollectionUnit.tsx
+++ b/src/components/Modal/CollectionModal/CollectionUnit.tsx
@@ -28,7 +28,7 @@ const CollectionUnit = ({
 
   return (
     <button
-      className='flex tablet:flex-col items-center gap-[8px] tablet:p-0 p-[9px]'
+      className='flex tablet:flex-col items-center tabelt:gap-[8px] gap-4 tablet:p-0 p-[9px]'
       onClick={selectCollectionUnit}
       disabled={blockButton}
     >
@@ -40,8 +40,10 @@ const CollectionUnit = ({
         />
       </div>
       <div className='flex flex-1 tablet:flex-col justify-between items-center tablet:gap-[3px] gap-[19px]'>
-        <p className='subtitle2 text-white'>{name}</p>
-        <div className='flex items-center gap-0.5 body2 text-gray-500'>
+        <p className='subtitle2 tablet:max-w-[180px] max-w-[135px] text-white text-ellipsis overflow-hidden whitespace-nowrap'>
+          {name}
+        </p>
+        <div className='flex items-center gap-0.5 tablet:body2 button-s text-gray-500'>
           <Icon name={status === 'PRIVATE' ? 'Lock' : 'Unlock'} size='s' />
           <p>{status === 'PRIVATE' ? '비공개' : '전체 공개'}</p>
         </div>

--- a/src/components/Modal/CollectionModal/CreateCollectionUnit.tsx
+++ b/src/components/Modal/CollectionModal/CreateCollectionUnit.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useStore } from 'zustand';
+
+import Icon from '@/components/Icon/Icon';
+import modalStore from '@/stores/modalStore';
+
+import CreateCollectionModal from '../CreateCollectionModal';
+
+const CreateCollectionUnit = () => {
+  const { openModal, closeModal } = useStore(modalStore);
+
+  const handleCreateCollecion = () => {
+    closeModal();
+
+    openModal({
+      modalSize: 'md',
+      contents: <CreateCollectionModal />,
+    });
+  };
+
+  return (
+    <button
+      className='flex tablet:flex-col items-center gap-[8px] tablet:p-0 p-[9px]'
+      onClick={handleCreateCollecion}
+    >
+      <div
+        className='flex justify-center items-center tablet:w-full tablet:h-[200px] w-[70px] h-[70px] rounded-[5px] overflow-hidden'
+        style={{
+          border: '2px dashed transparent',
+          borderImage:
+            'repeating-linear-gradient(45deg, gray 0, gray 10px, transparent 10px, transparent 20px) 1',
+        }}
+      >
+        <Icon name='Plus' size='l' className='text-gray-500' />
+      </div>
+      <p className='subtitle2 text-white'>컬렉션 생성</p>
+    </button>
+  );
+};
+
+export default CreateCollectionUnit;

--- a/src/components/Modal/CollectionModal/index.tsx
+++ b/src/components/Modal/CollectionModal/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useStore } from 'zustand';
+
+import Icon from '@/components/Icon/Icon';
+import useGetAllCollectionList from '@/hooks/serverStateHooks/useGetCollectionList';
+import modalStore from '@/stores/modalStore';
+
+import CollectionUnit from './CollectionUnit';
+import CreateCollectionUnit from './CreateCollectionUnit';
+
+const CollectionModal = () => {
+  const { closeModal } = useStore(modalStore);
+  const { collections, isLoading } = useGetAllCollectionList();
+
+  if (isLoading) return <div>Loading</div>;
+
+  return (
+    <div className='flex flex-col gap-[50px] tablet:pl-[56px] tablet:pr-[22px] px-[18px] py-[50px]'>
+      <div className='flex justify-between items-center tablet:pr-[34px]'>
+        <h2 className='text-white'>컬렉션에 저장</h2>
+        <Icon
+          name='Close'
+          size='l'
+          className='text-gray-500'
+          onClick={closeModal}
+        />
+      </div>
+      <div className='grid tablet:grid-cols-4 grid-cols-1 gap-x-[33px] gap-y-[30px] max-h-[555px] tablet:pr-[34px] overflow-y-auto'>
+        <CreateCollectionUnit />
+        {collections.map((collection) => (
+          <CollectionUnit
+            key={collection.collectionId}
+            collectionInfo={collection}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CollectionModal;

--- a/src/components/Modal/CollectionModal/index.tsx
+++ b/src/components/Modal/CollectionModal/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import '@/styles/scroll.css';
+
 import { useStore } from 'zustand';
 
 import Icon from '@/components/Icon/Icon';
@@ -26,7 +28,7 @@ const CollectionModal = () => {
           onClick={closeModal}
         />
       </div>
-      <div className='grid tablet:grid-cols-4 grid-cols-1 gap-x-[33px] gap-y-[30px] max-h-[555px] tablet:pr-[34px] overflow-y-auto'>
+      <div className='grid tablet:grid-cols-4 grid-cols-1 gap-x-[33px] gap-y-[30px] max-h-[555px] tablet:pr-[34px] overflow-y-auto scroll-hide'>
         <CreateCollectionUnit />
         {collections.map((collection) => (
           <CollectionUnit

--- a/src/components/Modal/ConfirmModal.tsx
+++ b/src/components/Modal/ConfirmModal.tsx
@@ -9,12 +9,20 @@ interface ConfirmModalProps {
   isButtonOnRow?: boolean;
   reverseButtonOrder?: boolean;
   children: ReactNode;
+  confirmButtonText?: string;
+  otherButtonText?: string;
+  onClickConfirmButton?: () => void;
+  onClickOtherButton?: () => void;
 }
 
 const ConfirmModal = ({
   isButtonOnRow = false,
   reverseButtonOrder = false,
   children,
+  confirmButtonText = '확인',
+  otherButtonText = '취소',
+  onClickConfirmButton,
+  onClickOtherButton,
 }: ConfirmModalProps) => {
   const { closeModal } = useStore(modalStore);
 
@@ -30,11 +38,17 @@ const ConfirmModal = ({
     <div className='px-[40px] py-[50px] text-center'>
       <div className='body1 text-white mb-[50px]'>{children}</div>
       <div className={`flex ${buttonOrderClassName} gap-[20px]`}>
-        <SquareButtonL variant='primary'>
-          <p>확인</p>
+        <SquareButtonL
+          variant='primary'
+          onClick={onClickConfirmButton || closeModal}
+        >
+          <p>{confirmButtonText}</p>
         </SquareButtonL>
-        <SquareButtonL variant='tertiary' onClick={closeModal}>
-          <p>취소</p>
+        <SquareButtonL
+          variant='tertiary'
+          onClick={onClickOtherButton || closeModal}
+        >
+          <p>{otherButtonText}</p>
         </SquareButtonL>
       </div>
     </div>

--- a/src/components/Modal/CreateCollectionModal.tsx
+++ b/src/components/Modal/CreateCollectionModal.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { ChangeEvent, useState } from 'react';
+import { useStore } from 'zustand';
+
+import usePostCreateCollection from '@/hooks/serverStateHooks/usePostCreateCollection';
+import modalStore from '@/stores/modalStore';
+
+import SquareButtonL from '../Button/SquareButtonL';
+import Icon from '../Icon/Icon';
+import BasicInput from '../Input/BasicInput';
+
+const CreateCollectionModal = () => {
+  const { closeModal } = useStore(modalStore);
+
+  const [collectionName, setCollectionName] = useState('');
+  const [isPrivate, setIsPrivate] = useState(false);
+
+  const { mutate: submitCreateCollection } = usePostCreateCollection();
+
+  const handlOnChangeCollectionName = (
+    event: ChangeEvent<HTMLInputElement>,
+  ) => {
+    setCollectionName(event.target.value);
+  };
+
+  const clickCreateButton = () => {
+    submitCreateCollection({ name: collectionName, isPrivate });
+  };
+
+  const clickSetPrivateCheck = () => {
+    setIsPrivate((state) => !state);
+  };
+
+  return (
+    <div className='flex flex-col tablet:px-[56px] px-[18px] py-[50px]'>
+      <div className='flex justify-between items-center'>
+        <h2 className='text-white'>컬렉션에 저장</h2>
+        <Icon
+          name='Close'
+          size='l'
+          className='text-gray-500'
+          onClick={closeModal}
+        />
+      </div>
+      <div className='grid grid-cols-[1fr_100px] mt-[100px] mb-[75px] gap-x-2.5'>
+        <BasicInput
+          value={collectionName}
+          onChange={handlOnChangeCollectionName}
+          label='컬렉션 이름'
+          placeholder='컬렉션 이름을 입력하세요.'
+          showTextLength={true}
+          maxLength={10}
+        />
+        <span className='h-[60px] mt-[23px]'>
+          <SquareButtonL
+            variant={'primary'}
+            onClick={clickCreateButton}
+            disabled={collectionName.length === 0}
+          >
+            생성
+          </SquareButtonL>
+        </span>
+        <button
+          className='flex items-center gap-2.5'
+          onClick={clickSetPrivateCheck}
+        >
+          <Icon
+            name='CheckCircleFilled'
+            size='s'
+            className={isPrivate ? 'text-main' : 'text-gray-700'}
+          />
+          <p className='placeholder text-white'>비공개로 설정</p>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CreateCollectionModal;

--- a/src/components/Modal/CreateCollectionModal.tsx
+++ b/src/components/Modal/CreateCollectionModal.tsx
@@ -18,7 +18,7 @@ const CreateCollectionModal = () => {
 
   const { mutate: submitCreateCollection } = usePostCreateCollection();
 
-  const handlOnChangeCollectionName = (
+  const handleOnChangeCollectionName = (
     event: ChangeEvent<HTMLInputElement>,
   ) => {
     setCollectionName(event.target.value);
@@ -46,7 +46,7 @@ const CreateCollectionModal = () => {
       <div className='grid grid-cols-[1fr_100px] mt-[100px] mb-[75px] gap-x-2.5'>
         <BasicInput
           value={collectionName}
-          onChange={handlOnChangeCollectionName}
+          onChange={handleOnChangeCollectionName}
           label='컬렉션 이름'
           placeholder='컬렉션 이름을 입력하세요.'
           showTextLength={true}

--- a/src/components/Modal/ShareModal.tsx
+++ b/src/components/Modal/ShareModal.tsx
@@ -19,7 +19,7 @@ const ShareModal = ({ nickname, title }: ShareModalProps) => {
   const [shareURL, setShareURL] = useState(window.location.href);
   const [copyStatus, setCopyStatus] = useState(false);
 
-  const handlOnChangeShareURL = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleOnChangeShareURL = (event: ChangeEvent<HTMLInputElement>) => {
     setShareURL(event.target.value);
   };
 
@@ -47,11 +47,11 @@ const ShareModal = ({ nickname, title }: ShareModalProps) => {
         <BasicInput
           type='text'
           value={shareURL}
-          onChange={handlOnChangeShareURL}
+          onChange={handleOnChangeShareURL}
         />
         <span className='h-[60px]'>
           <SquareButtonL
-            variant={'tertiary'}
+            variant='tertiary'
             children={copyStatus ? '복사 완료' : 'URL 복사'}
             onClick={clickCopyButton}
           />

--- a/src/components/Modal/ShareModal.tsx
+++ b/src/components/Modal/ShareModal.tsx
@@ -9,7 +9,12 @@ import BasicInput from '@/components/Input/BasicInput';
 import modalStore from '@/stores/modalStore';
 import copyClipboard from '@/utils/copyClipboard';
 
-const ShareModal = () => {
+interface ShareModalProps {
+  nickname: string;
+  title: string;
+}
+
+const ShareModal = ({ nickname, title }: ShareModalProps) => {
   const { closeModal } = useStore(modalStore);
   const [shareURL, setShareURL] = useState(window.location.href);
   const [copyStatus, setCopyStatus] = useState(false);
@@ -35,8 +40,8 @@ const ShareModal = () => {
         />
       </div>
       <div className='flex gap-5 items-center body1 mt-5'>
-        <p className='text-gray-200'>작품 이름</p>
-        <p className='text-gray-300'>작가 닉네임</p>
+        <p className='text-gray-200'>{title}</p>
+        <p className='text-gray-300'>{nickname}</p>
       </div>
       <div className='grid grid-cols-[1fr_100px] mt-[100px] mb-[75px] gap-2.5'>
         <BasicInput

--- a/src/components/Modal/ShareModal.tsx
+++ b/src/components/Modal/ShareModal.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { ChangeEvent, useState } from 'react';
+import { useStore } from 'zustand';
+
+import SquareButtonL from '@/components/Button/SquareButtonL';
+import Icon from '@/components/Icon/Icon';
+import BasicInput from '@/components/Input/BasicInput';
+import modalStore from '@/stores/modalStore';
+import copyClipboard from '@/utils/copyClipboard';
+
+const ShareModal = () => {
+  const { closeModal } = useStore(modalStore);
+  const [shareURL, setShareURL] = useState(window.location.href);
+  const [copyStatus, setCopyStatus] = useState(false);
+
+  const handlOnChangeShareURL = (event: ChangeEvent<HTMLInputElement>) => {
+    setShareURL(event.target.value);
+  };
+
+  const clickCopyButton = async () => {
+    const copyResult = await copyClipboard(shareURL);
+    setCopyStatus(copyResult);
+  };
+
+  return (
+    <div className='flex flex-col tablet:px-[56px] px-[18px] py-[50px]'>
+      <div className='flex justify-between items-center'>
+        <h2 className='text-white'>작품 공유</h2>
+        <Icon
+          name='Close'
+          size='l'
+          className='text-gray-500'
+          onClick={closeModal}
+        />
+      </div>
+      <div className='flex gap-5 items-center body1 mt-5'>
+        <p className='text-gray-200'>작품 이름</p>
+        <p className='text-gray-300'>작가 닉네임</p>
+      </div>
+      <div className='grid grid-cols-[1fr_100px] mt-[100px] mb-[75px] gap-2.5'>
+        <BasicInput
+          type='text'
+          value={shareURL}
+          onChange={handlOnChangeShareURL}
+        />
+        <span className='h-[60px]'>
+          <SquareButtonL
+            variant={'tertiary'}
+            children={copyStatus ? '복사 완료' : 'URL 복사'}
+            onClick={clickCopyButton}
+          />
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default ShareModal;

--- a/src/constants/API.ts
+++ b/src/constants/API.ts
@@ -16,6 +16,7 @@ const MONTHLY = {
 const ARTWORK = {
   artworkList: '/artwork/posts',
   followedArtists: '/artwork/followingUsers/posts',
+  artworkLike: (postId: number) => `/artwork/post/${postId}/like`,
 };
 
 const COLLECTION = {

--- a/src/constants/API.ts
+++ b/src/constants/API.ts
@@ -18,4 +18,12 @@ const ARTWORK = {
   followedArtists: '/artwork/followingUsers/posts',
 };
 
-export { ARTWORK, MONTHLY, USER };
+const COLLECTION = {
+  collection: '/collection',
+  allCollectionsList: '/collections/all',
+  collectionList: '/collections',
+  collectionAddArtwork: (collectionId: number, postId: number) =>
+    `/collection/${collectionId}/post/${postId}`,
+};
+
+export { ARTWORK, COLLECTION, MONTHLY, USER };

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -35,3 +35,10 @@ export const COMMON_ERROR_MESSAGE: MessageConstantType = {
   UNKNOWN_ERROR: '알 수 없는 에러가 발생했습니다. 다시 시도해주세요.',
   NETWORK_ERROR: '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.',
 };
+
+export const COLLECTION_ADD_ARTWORK_ERROR_MESSAGE: MessageConstantType = {
+  COLLECTION_NOT_FOUND: '컬랙션 리소스를 찾을 수 없습니다.',
+  POST_NOT_FOUND: '작품 리소스를 찾을 수 없습니다.',
+  DUPLICATE_COLLECTION_ARTWORK: '컬랙션에 이미 저장된 작품입니다.',
+  NO_PERMISSION: '컬렉션에 대한 권한이 없습니다.',
+};

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -36,6 +36,13 @@ export const COMMON_ERROR_MESSAGE: MessageConstantType = {
   NETWORK_ERROR: '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.',
 };
 
+export const LIKE_ERROR_MESSAGE: MessageConstantType = {
+  ALREADY_LIKE: '이미 좋아요한 작품입니다.',
+  POST_NOT_FOUND: '요청한 리소스가 없습니다.',
+  LIKE_ALREADY_REMOVED:
+    '좋아요 하지 않은 작품이거나 이미 좋아요 취소된 작품입니다.',
+};
+
 export const COLLECTION_ADD_ARTWORK_ERROR_MESSAGE: MessageConstantType = {
   COLLECTION_NOT_FOUND: '컬랙션 리소스를 찾을 수 없습니다.',
   POST_NOT_FOUND: '작품 리소스를 찾을 수 없습니다.',

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -4,6 +4,7 @@ const ROUTE = {
   signUp: '/auth/sign-up',
   artworkList: '/artwork/list',
   artworkUpload: '/artwork/upload',
+  collections: '/collections',
 };
 
 export default ROUTE;

--- a/src/hooks/serverStateHooks/useGetCollectionList.ts
+++ b/src/hooks/serverStateHooks/useGetCollectionList.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import getAllCollectionList from '@/apis/collection/getAllCollectionList';
+import { COLLECTION } from '@/constants/API';
+import { CollectionType } from '@/types/collection';
+
+const useGetAllCollectionList = () => {
+  const { data, isLoading } = useQuery({
+    queryKey: [COLLECTION.collectionList],
+    queryFn: () => getAllCollectionList(),
+  });
+
+  return {
+    collections: data ? data.collections : ([] as CollectionType[]),
+    isLoading,
+  };
+};
+
+export default useGetAllCollectionList;

--- a/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
+++ b/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
@@ -5,6 +5,7 @@ import { useStore } from 'zustand';
 import postCollectionAddArtwork from '@/apis/collection/postCollectionAddArtwork';
 import ConfirmModal from '@/components/Modal/ConfirmModal';
 import { COLLECTION } from '@/constants/API';
+import ROUTE from '@/constants/routes';
 import modalStore from '@/stores/modalStore';
 
 const usePostCollectionAddArtwork = ({
@@ -32,7 +33,7 @@ const usePostCollectionAddArtwork = ({
           <ConfirmModal
             otherButtonText='컬렉션으로 이동'
             onClickOtherButton={() => {
-              router.push('/collections');
+              router.push(ROUTE.collections);
             }}
           >
             <p className='body1'>작품이 컬렉션에 저장되었습니다.</p>

--- a/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
+++ b/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
@@ -30,7 +30,7 @@ const usePostCollectionAddArtwork = ({
         modalSize: 'sm',
         contents: (
           <ConfirmModal
-            otherButtonText='컬렉션으로 이돋'
+            otherButtonText='컬렉션으로 이동'
             onClickOtherButton={() => {
               router.push('/collections');
             }}

--- a/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
+++ b/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
@@ -1,0 +1,48 @@
+import { useMutation } from '@tanstack/react-query';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useStore } from 'zustand';
+
+import postCollectionAddArtwork from '@/apis/collection/postCollectionAddArtwork';
+import ConfirmModal from '@/components/Modal/ConfirmModal';
+import { COLLECTION } from '@/constants/API';
+import modalStore from '@/stores/modalStore';
+
+const usePostCollectionAddArtwork = ({
+  collectionId,
+}: {
+  collectionId: number;
+}) => {
+  const router = useRouter();
+  const { openModal, closeModal } = useStore(modalStore);
+
+  const searchParams = useSearchParams();
+  const artworkId = Number(searchParams.get('artworkId'));
+
+  const { mutate } = useMutation({
+    mutationKey: [COLLECTION.collectionAddArtwork(collectionId, artworkId)],
+    mutationFn: () =>
+      postCollectionAddArtwork({ collectionId, postId: artworkId }),
+    onSuccess: () => {
+      console.log(111);
+      closeModal();
+
+      openModal({
+        modalSize: 'sm',
+        contents: (
+          <ConfirmModal
+            otherButtonText='컬렉션으로 이돋'
+            onClickOtherButton={() => {
+              router.push('/collections');
+            }}
+          >
+            <p className='body1'>작품이 컬렉션에 저장되었습니다.</p>
+          </ConfirmModal>
+        ),
+      });
+    },
+  });
+
+  return { mutate };
+};
+
+export default usePostCollectionAddArtwork;

--- a/src/hooks/serverStateHooks/usePostCreateCollection.tsx
+++ b/src/hooks/serverStateHooks/usePostCreateCollection.tsx
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { useStore } from 'zustand';
+
+import postCreateCollection from '@/apis/collection/postCreateCollection';
+import CollectionModal from '@/components/Modal/CollectionModal';
+import { COLLECTION } from '@/constants/API';
+import modalStore from '@/stores/modalStore';
+
+const usePostCreateCollection = () => {
+  const { openModal, closeModal } = useStore(modalStore);
+  const { mutate } = useMutation({
+    mutationKey: [COLLECTION.collection],
+    mutationFn: ({ name, isPrivate }: { name: string; isPrivate: boolean }) =>
+      postCreateCollection(name, isPrivate),
+    onSuccess: () => {
+      closeModal();
+
+      openModal({
+        modalSize: 'lg',
+        contents: <CollectionModal />,
+      });
+    },
+  });
+
+  return { mutate };
+};
+
+export default usePostCreateCollection;

--- a/src/hooks/serverStateHooks/usePostCreateCollection.tsx
+++ b/src/hooks/serverStateHooks/usePostCreateCollection.tsx
@@ -1,7 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import { useStore } from 'zustand';
 
-import postCreateCollection from '@/apis/collection/postCreateCollection';
+import postCreateCollection, {
+  PostCreateColleactionProps,
+} from '@/apis/collection/postCreateCollection';
 import CollectionModal from '@/components/Modal/CollectionModal';
 import { COLLECTION } from '@/constants/API';
 import modalStore from '@/stores/modalStore';
@@ -10,8 +12,8 @@ const usePostCreateCollection = () => {
   const { openModal, closeModal } = useStore(modalStore);
   const { mutate } = useMutation({
     mutationKey: [COLLECTION.collection],
-    mutationFn: ({ name, isPrivate }: { name: string; isPrivate: boolean }) =>
-      postCreateCollection(name, isPrivate),
+    mutationFn: ({ name, isPrivate }: PostCreateColleactionProps) =>
+      postCreateCollection({ name, isPrivate }),
     onSuccess: () => {
       closeModal();
 

--- a/src/hooks/serverStateHooks/useToggleLike.ts
+++ b/src/hooks/serverStateHooks/useToggleLike.ts
@@ -1,0 +1,37 @@
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import deleteArtworkLike from '@/apis/artwork/deleteArtworkLike';
+import postArtworkLike from '@/apis/artwork/postArtworkLike';
+
+interface UseToggleLikeProps {
+  isLiked: boolean;
+  likeCount: number;
+}
+
+const useToggleLike = (initialLikeStatus: UseToggleLikeProps) => {
+  const [likeStatus, setLikeStatus] = useState(initialLikeStatus);
+  const { isLiked, likeCount } = likeStatus;
+  const { mutate } = useMutation<void, Error, number>({
+    mutationFn: async (postId: number) => {
+      isLiked === true
+        ? await deleteArtworkLike(postId)
+        : await postArtworkLike(postId);
+    },
+
+    onSuccess: () => {
+      setLikeStatus({
+        isLiked: !isLiked,
+        likeCount: isLiked ? likeCount - 1 : likeCount + 1,
+      });
+    },
+
+    onError: (error) => {
+      console.error('팔로우 상태 변경 에러: ', error.message);
+    },
+  });
+
+  return { mutate, ...likeStatus, setLikeStatus };
+};
+
+export default useToggleLike;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -92,4 +92,13 @@
     vertical-align: middle;
     fill: currentColor; /* 텍스트 색상과 동일하게 적용 */
   }
+
+  .scroll-hide::-webkit-scrollbar {
+    display: none;
+  }
+
+  .scroll-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -92,13 +92,4 @@
     vertical-align: middle;
     fill: currentColor; /* 텍스트 색상과 동일하게 적용 */
   }
-
-  .scroll-hide::-webkit-scrollbar {
-    display: none;
-  }
-
-  .scroll-hide {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
 }

--- a/src/styles/scroll.css
+++ b/src/styles/scroll.css
@@ -1,0 +1,10 @@
+@media (max-width: 1400px) {
+  .scroll-hide::-webkit-scrollbar {
+    display: none;
+  }
+
+  .scroll-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+}

--- a/src/types/artwork.ts
+++ b/src/types/artwork.ts
@@ -12,6 +12,17 @@ export interface ArtworkInfoType {
   isLiked: boolean;
 }
 
+export interface ArtworkPostType extends ArtworkInfoType {
+  artworkField: string;
+  createdTime: string;
+  explanation: string;
+  profileImage: string | null;
+  userField: string | null;
+  isFollow: boolean;
+  introduction: string;
+  isMine: boolean;
+}
+
 export interface ArtworkListParams {
   sort: string;
   artworkField?: string;
@@ -29,3 +40,9 @@ export interface ArtworkField {
   name: string;
   value: string;
 }
+
+export interface ArtworkPostSocialInfoType
+  extends Pick<
+    ArtworkPostType,
+    'postId' | 'nickname' | 'title' | 'likeCount' | 'isLiked'
+  > {}

--- a/src/types/collection.ts
+++ b/src/types/collection.ts
@@ -1,0 +1,6 @@
+export interface CollectionType {
+  collectionId: number;
+  collectionImage: string;
+  name: string;
+  status: 'PUBLIC' | 'PRIVATE';
+}

--- a/src/utils/copyClipboard.ts
+++ b/src/utils/copyClipboard.ts
@@ -1,0 +1,16 @@
+const copyClipboard = async (text: string) => {
+  try {
+    if (typeof window !== 'undefined' && navigator.clipboard) {
+      await navigator.clipboard.writeText(text);
+
+      return true;
+    } else {
+      throw new Error('Clipboard API not available');
+    }
+  } catch (e) {
+    console.error(e);
+    return false;
+  }
+};
+
+export default copyClipboard;


### PR DESCRIPTION
## 📝 작업 내용
[TASK-84] - 버튼 그룹 구현
- [x] 좋아요 버튼 및 좋아요 관련 API 로직 추가
- [x] 공유하기 버튼 구현
- [x] 컬랙션 추가 버튼 구현

[TASK-85] - 관련 모달 구현
- [x]  작품 공유 모달 구현
    - [x]  URL 복사 기능 추가
- [x]  컬렉션 저장 모달 구현
    - [x]  api 요청 및 성공시, 확인 모달 나오도록
- [x]  컬렉션 생성 모달 구현
    - [x]  api 요청 및 생성 후 다시 컬렉션 저장 모달이 노출되도록 동작 정의
- [x]  확인/취소 모달 레이아웃 수정
    - [x]  반응형 적용 및 의도에 따라 버튼 배치를 다르게 적용할 수 있도록 수정
- [x]  input, button이 필요한 모달의 경우 일부 디자인 시스템 컴포넌트 수정

## 📸 스크린샷

### 우측 버튼 그룹 ( 좋아요 / 좋아요 해제 )
<img width="165" alt="image" src="https://github.com/user-attachments/assets/9d4b33f3-6c78-4ddf-88ec-ded29b22dbc6" />
<img width="171" alt="image" src="https://github.com/user-attachments/assets/0f0394f0-9c38-4618-8ce1-f7600ad60d1f" />

### 관련 모달
- 작품 공유 모달
<img width="443" alt="image" src="https://github.com/user-attachments/assets/aa96bd60-e4bb-460b-a935-a9a0bf9b2a24" />
<img width="422" alt="image" src="https://github.com/user-attachments/assets/005e804b-fc07-4bd4-abb2-5f90e29f4be7" />


- 컬렉션 저장 모달
<img width="542" alt="image" src="https://github.com/user-attachments/assets/f766ccbb-fdfe-42d8-84e4-7611d86309b7" />

- 컬렉션 생성 모달
<img width="461" alt="image" src="https://github.com/user-attachments/assets/a4fac54a-076c-4c3b-8ebb-13e641ad5a6c" />
<img width="455" alt="image" src="https://github.com/user-attachments/assets/7c43c4a0-859f-4b94-a72e-867774d3a5b4" />


- 확인/취소 모달  
**위 컬렉션 저장 모달에서 작품을 컬렉션에 저장 완료되었을 경우 나타나는 모달**
<img width="291" alt="image" src="https://github.com/user-attachments/assets/76436ca7-cdbe-4e73-9341-d9e70155c6a1" />


## 특이사항
이번 PR 기준으로 리뷰 마무리되는대로 나머지 영역에 대한 코드도 차례로 이어서 PR 추가하겠습니다...! 