### PR TITLE
[TASK-87, TASK-89] feat: 작품 상세 본문 영역, 작가 정보 영역 컴포넌트 추가

### DIFF
--- a/src/apis/artwork/deleteArtworkPost.ts
+++ b/src/apis/artwork/deleteArtworkPost.ts
@@ -1,0 +1,41 @@
+import { isAxiosError } from 'axios';
+
+import { ARTWORK } from '@/constants/API';
+import {
+  ARTWORK_POST_ERROR_MESSAGE,
+  COMMON_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { ErrorResponseType } from '@/types/errorResponse';
+
+import { authorizedClient } from '..';
+
+const deleteArtworkPost = async (postId: number) => {
+  try {
+    const response = await authorizedClient.delete<null>(
+      `${ARTWORK.artworkPost}/${postId}`,
+    );
+
+    if (response.status === 204) {
+      return true;
+    } else {
+      throw new Error('작품 삭제 실패');
+    }
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        console.error(ARTWORK_POST_ERROR_MESSAGE[code]);
+        throw new Error(ARTWORK_POST_ERROR_MESSAGE[code]);
+      } else {
+        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+        throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+  }
+};
+
+export default deleteArtworkPost;

--- a/src/components/ArtworkDetailPage/ArtistInfoSection.tsx
+++ b/src/components/ArtworkDetailPage/ArtistInfoSection.tsx
@@ -1,0 +1,52 @@
+import Image from 'next/image';
+
+import DefaultProfileImage from '@/../public/images/defaultProfileImage.png';
+import { ArtworkPostArtistInfoType } from '@/types';
+
+import FollowButton from '../Button/FollowButton';
+
+interface ArtistInfoSectionProps {
+  artistInfo: ArtworkPostArtistInfoType;
+}
+
+const ArtistInfoSection = ({
+  artistInfo: {
+    userId,
+    profileImage,
+    nickname,
+    userField,
+    isFollow,
+    introduction,
+  },
+}: ArtistInfoSectionProps) => {
+  return (
+    <div className='tablet:w-[470px] flex flex-col gap-[20px]'>
+      <h2>작가 정보</h2>
+      <div className='tablet:px-[60px] px-[10px] py-9 rounded-[10px] bg-gray-900'>
+        <div className='flex gap-[42px] justify-center items-center'>
+          <Image
+            src={profileImage || DefaultProfileImage}
+            alt='profile-image'
+            className='object-contain rounded-full'
+            width={141}
+            height={141}
+          />
+          <div className='flex flex-col flex-1 gap-[22px] subtitle2'>
+            <p>{nickname}</p>
+            <p>{userField}</p>
+          </div>
+        </div>
+        <p className='subtitle2 mt-[30px] mb-[40px]'>
+          {introduction || '작가 소개가 비어있습니다.'}
+        </p>
+        <FollowButton
+          initFollowState={isFollow}
+          followUserId={userId}
+          isFull={true}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ArtistInfoSection;

--- a/src/components/ArtworkDetailPage/ArtworkDetailHeader.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkDetailHeader.tsx
@@ -1,0 +1,52 @@
+import Image from 'next/image';
+
+import DefaultProfileImage from '@/../public/images/defaultProfileImage.png';
+import { ArtworkPostHeaderInfoType } from '@/types';
+import timeFormatter from '@/utils/timeFormatter';
+
+import Icon from '../Icon/Icon';
+
+interface ArtworkDetailHeaderProps {
+  headerInfo: ArtworkPostHeaderInfoType;
+}
+
+const ArtworkDetailHeader = ({
+  headerInfo: {
+    title,
+    artworkField,
+    viewCount,
+    profileImage,
+    nickname,
+    createdTime,
+  },
+}: ArtworkDetailHeaderProps) => {
+  return (
+    <div>
+      <div className='flex gap-[50px] items-center mb-[40px]'>
+        <h1>{title}</h1>
+        <p className='subtitle1 border-l-1 pl-[50px] border-white'>
+          {artworkField}
+        </p>
+      </div>
+      <div className='flex items-center gap-[22px]'>
+        <Image
+          src={profileImage || DefaultProfileImage}
+          alt={profileImage ? 'artwork image' : 'artwork default image'}
+          className='object-contain rounded-full'
+          width={67}
+          height={67}
+        />
+        <p>{nickname}</p>
+      </div>
+      <div className='flex tablet:flex-row flex-col tablet:gap-[22px] justify-end tablet:items-center items-end'>
+        <div className='flex gap-[13px] justify-end items-center'>
+          <Icon name='Eye' size='s' />
+          <p>{viewCount}</p>
+        </div>
+        <p>{timeFormatter(createdTime)}</p>
+      </div>
+    </div>
+  );
+};
+
+export default ArtworkDetailHeader;

--- a/src/components/ArtworkDetailPage/ArtworkDetailInfoSection.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkDetailInfoSection.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useStore } from 'zustand';
+
+import ROUTE from '@/constants/routes';
+import useDeleteArtworkPost from '@/hooks/serverStateHooks/useDeleteArtworkPost';
+import modalStore from '@/stores/modalStore';
+import { ArtworkPostdetailInfoType } from '@/types';
+
+import Icon from '../Icon/Icon';
+import ConfirmModal from '../Modal/ConfirmModal';
+
+interface ArtworkDetailInfoSectionProps {
+  detailInfo: ArtworkPostdetailInfoType;
+}
+
+const ArtworkDetailInfoSection = ({
+  detailInfo: { postId, userId, postImage, explanation, isMine },
+}: ArtworkDetailInfoSectionProps) => {
+  const router = useRouter();
+
+  const { openModal, closeModal } = useStore(modalStore);
+  const [showWiderArtwork, setShowWideArtwork] = useState(false);
+
+  const { mutate: deleteArtwork } = useDeleteArtworkPost(postId);
+
+  const clickEditButton = () => {
+    router.push(`${ROUTE.artworkUpload}?postId=${postId}&userId=${userId}`);
+  };
+
+  const comfirmDelete = () => {
+    deleteArtwork(undefined, {
+      onSuccess: () => {
+        router.replace(ROUTE.artworkList);
+        closeModal();
+      },
+    });
+  };
+
+  const clickDeleteButton = () => {
+    openModal({
+      modalSize: 'sm',
+      contents: (
+        <ConfirmModal
+          onClickConfirmButton={comfirmDelete}
+          onClickOtherButton={closeModal}
+          isButtonOnRow={false}
+          reverseButtonOrder={true}
+        >
+          <p>
+            작품을 삭제하시겠습니까?
+            <br />
+            삭제한 작품은 복구할 수 없습니다.
+          </p>
+        </ConfirmModal>
+      ),
+    });
+  };
+
+  useEffect(() => {
+    if (showWiderArtwork) document.body.style.overflow = 'hidden';
+
+    return () => {
+      if (showWiderArtwork) document.body.style.overflow = 'auto';
+    };
+  }, [showWiderArtwork]);
+
+  return (
+    <div className='relative flex flex-col gap-10'>
+      <div className='relative w-full h-[853px]'>
+        <Image
+          src={postImage}
+          alt='post-image'
+          fill={true}
+          className='object-contain'
+        />
+        <button
+          className='absolute bottom-[30px] right-[30px] tablet:p-[23.5px] p-[16.5px] rounded-full bg-background-overlay/50'
+          onClick={() => setShowWideArtwork(true)}
+        >
+          <Icon
+            name='ExternalLink'
+            className='tablet:w-[30px] tablet:h-[30px]'
+          />
+        </button>
+      </div>
+      <div className='flex items-center gap-5 text-gray-600'>
+        <Icon name='AlertCircle' size='m' />
+        <p>
+          모멘티아에 게시된 모든 작품의 이미지 및 콘텐츠는 저작권법에 의해
+          보호받고 있으며 무단 복제, 배포, 사용 시 법적 책임이 따를 수 있습니다.
+        </p>
+      </div>
+      <div className='flex flex-col gap-5'>
+        <div className='flex justify-between'>
+          <h2>작품 설명</h2>
+          {isMine && (
+            <div className='flex gap-[30px]'>
+              <button onClick={clickEditButton}>수정</button>
+              <button onClick={clickDeleteButton}>삭제</button>
+            </div>
+          )}
+        </div>
+        <div className='min-h-[256px] p-5 rounded-[10px] bg-gray-900'>
+          <p>{explanation}</p>
+        </div>
+      </div>
+      {showWiderArtwork && (
+        <div className='fixed left-0 top-0 w-full h-full bg-black/80 z-50 py-[111px]'>
+          <button
+            className='absolute right-[138px] top-[15px] p-[23px] bg-background-overlay/80 rounded-full'
+            onClick={() => setShowWideArtwork(false)}
+          >
+            <Icon name='Close' size='l' />
+          </button>
+          <div className='relative w-full h-full'>
+            <Image
+              src={postImage}
+              alt='post-image'
+              fill={true}
+              className='object-contain'
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ArtworkDetailInfoSection;

--- a/src/components/Button/FollowButton.tsx
+++ b/src/components/Button/FollowButton.tsx
@@ -11,6 +11,7 @@ const FollowButton = ({
   initFollowState,
   followUserId,
   ariaLabel,
+  isFull = false,
 }: FollowButtonProps) => {
   const [isFollowing, setIsFollowing] = useState(initFollowState);
   const { mutate: toggleFollow } = useToggleFollow({
@@ -26,7 +27,7 @@ const FollowButton = ({
       aria-label={ariaLabel}
       className={`
         button-s flex items-center justify-center rounded-full
-        w-[95px] h-[37px] gap-[3px] ml-auto
+        ${isFull ? 'w-full' : 'w-fit'} px-4 h-[37px] gap-[3px] ml-auto
         ${
           isFollowing
             ? 'border	border-gray-900 text-gray-900 bg-white'

--- a/src/constants/API.ts
+++ b/src/constants/API.ts
@@ -16,6 +16,7 @@ const MONTHLY = {
 const ARTWORK = {
   artworkList: '/artwork/posts',
   followedArtists: '/artwork/followingUsers/posts',
+  artworkPost: '/artwork/post',
   artworkLike: (postId: number) => `/artwork/post/${postId}/like`,
 };
 

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -43,6 +43,11 @@ export const LIKE_ERROR_MESSAGE: MessageConstantType = {
     '좋아요 하지 않은 작품이거나 이미 좋아요 취소된 작품입니다.',
 };
 
+export const ARTWORK_POST_ERROR_MESSAGE: MessageConstantType = {
+  NO_PERMISSION: '본인 게시글이 아닙니다.',
+  ARTWORK_POST_NOT_FOUND: '리소스를 찾을 수 없습니다.',
+};
+
 export const COLLECTION_ADD_ARTWORK_ERROR_MESSAGE: MessageConstantType = {
   COLLECTION_NOT_FOUND: '컬랙션 리소스를 찾을 수 없습니다.',
   POST_NOT_FOUND: '작품 리소스를 찾을 수 없습니다.',

--- a/src/hooks/serverStateHooks/useDeleteArtworkPost.ts
+++ b/src/hooks/serverStateHooks/useDeleteArtworkPost.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+
+import deleteArtworkPost from '@/apis/artwork/deleteArtworkPost';
+import { ARTWORK } from '@/constants/API';
+
+const useDeleteArtworkPost = (postId: number) => {
+  const { mutate } = useMutation({
+    mutationKey: [ARTWORK.artworkPost, postId],
+    mutationFn: () => deleteArtworkPost(postId),
+  });
+
+  return { mutate };
+};
+
+export default useDeleteArtworkPost;

--- a/src/types/artwork.ts
+++ b/src/types/artwork.ts
@@ -57,3 +57,9 @@ export interface ArtworkPostHeaderInfoType
     | 'nickname'
     | 'createdTime'
   > {}
+
+export interface ArtworkPostdetailInfoType
+  extends Pick<
+    ArtworkPostType,
+    'postId' | 'userId' | 'postImage' | 'explanation' | 'isMine'
+  > {}

--- a/src/types/artwork.ts
+++ b/src/types/artwork.ts
@@ -63,3 +63,14 @@ export interface ArtworkPostdetailInfoType
     ArtworkPostType,
     'postId' | 'userId' | 'postImage' | 'explanation' | 'isMine'
   > {}
+
+export interface ArtworkPostArtistInfoType
+  extends Pick<
+    ArtworkPostType,
+    | 'userId'
+    | 'profileImage'
+    | 'nickname'
+    | 'userField'
+    | 'isFollow'
+    | 'introduction'
+  > {}

--- a/src/types/artwork.ts
+++ b/src/types/artwork.ts
@@ -46,3 +46,14 @@ export interface ArtworkPostSocialInfoType
     ArtworkPostType,
     'postId' | 'nickname' | 'title' | 'likeCount' | 'isLiked'
   > {}
+
+export interface ArtworkPostHeaderInfoType
+  extends Pick<
+    ArtworkPostType,
+    | 'title'
+    | 'artworkField'
+    | 'viewCount'
+    | 'profileImage'
+    | 'nickname'
+    | 'createdTime'
+  > {}

--- a/src/types/buttons/FollowButtonProps.ts
+++ b/src/types/buttons/FollowButtonProps.ts
@@ -13,4 +13,5 @@ export interface FollowButtonProps
   > {
   initFollowState: boolean;
   followUserId: number;
+  isFull?: boolean;
 }

--- a/src/utils/timeFormatter.ts
+++ b/src/utils/timeFormatter.ts
@@ -1,0 +1,30 @@
+const timeFormatter = (timeString: string) => {
+  const [dateData, timeData] = timeString.split('T');
+  const [year, month, date] = dateData.split('-').map(Number);
+  const [hour, minute, second] = timeData.split(':').map(Number);
+
+  const now = new Date();
+
+  const nowYear = now.getFullYear();
+  const nowMonth = now.getMonth() + 1;
+  const nowDate = now.getDate();
+
+  const nowHour = now.getUTCHours();
+  const nowMinute = now.getUTCMinutes();
+  const nowSeconds = now.getUTCSeconds();
+
+  if (nowYear !== year || nowMonth !== month || nowDate !== date)
+    return [
+      year,
+      month > 10 ? month : `0${month}`,
+      date > 10 ? date : `0${date}`,
+    ].join('.');
+
+  if (nowHour !== hour) return `${nowHour - hour}시간 전`;
+
+  if (nowMinute !== minute) return `${nowMinute - minute}분 전`;
+
+  return `${nowSeconds - second}초 전`;
+};
+
+export default timeFormatter;


### PR DESCRIPTION
## 📝 작업 내용
[TASK-87] 작품 상세 본문 영역 추가
- 상단 작품 정보 영역 컴포넌트 추가
- 작품 업로드 시간 포멧 수정 유틸 함수 추가  ex) 1시간전 (timeFomatter)
- 본문 작품 이미지 영역 컴포넌트 추가
- 작품 삭제 api 요청 로직, 커스텀 훅 추가

## 📸 스크린샷 (선택)
- 작품 이미지 영역
<img width="950" alt="image" src="https://github.com/user-attachments/assets/7362baeb-9985-46f8-99d1-d491b8b54268" />
- 작품 크게 보기 버튼 클릭시
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/c110156b-67c5-42a9-8967-e1d3f9eb21bd" />
- 작품 삭제버튼 클릭시
<img width="1680" alt="image" src="https://github.com/user-attachments/assets/99ab5fbc-45f6-4f18-a459-55fba3490944" />

- 작가 정보영역
<img width="278" alt="image" src="https://github.com/user-attachments/assets/c0ccc8aa-71a0-45f1-a765-7088c0c90295" />

## 💬 리뷰 요구사항 (선택)
- 작품 수정 버튼 클릭 이벤트에 작품 수정 페이지로 이동하도록 설정되어 있습니다..! 전에 한번 논의한 부분이긴 하지만 적절한 값을 넘겨 주고 있는지 한 번 확인 부탁드립니다-!
