### PR TITLE
[TASK-89] feat, fix: 작품 상세 페이지 미반영 부분 추가 반영

### DIFF
--- a/src/app/artwork/detail/page.tsx
+++ b/src/app/artwork/detail/page.tsx
@@ -15,8 +15,14 @@ const ArtworkDetailPage = () => {
   const searchParams = useSearchParams();
   const postId = Number(searchParams.get('postId'));
 
-  const { headerInfo, socialInfo, detailInfo, artistInfo, isLoading } =
-    useGetArtworkPost(postId);
+  const {
+    headerInfo,
+    socialInfo,
+    detailInfo,
+    artistInfo,
+    isLoading,
+    commentCount,
+  } = useGetArtworkPost(postId);
 
   useEffect(() => {
     if (!postId) router.back();
@@ -32,7 +38,7 @@ const ArtworkDetailPage = () => {
         <ButtonGroup socialInfo={socialInfo} />
         <div className='flex tablet:flex-row flex-col tablet:gap-10 gap-[70px] mt-10'>
           <ArtistInfoSection artistInfo={artistInfo} />
-          <ArtworkCommentSection postId={postId} />
+          <ArtworkCommentSection postId={postId} commentCount={commentCount} />
         </div>
       </div>
     </div>

--- a/src/components/ArtworkDetailPage/ArtistInfoSection.tsx
+++ b/src/components/ArtworkDetailPage/ArtistInfoSection.tsx
@@ -17,6 +17,7 @@ const ArtistInfoSection = ({
     userField,
     isFollow,
     introduction,
+    isMine,
   },
 }: ArtistInfoSectionProps) => {
   return (
@@ -39,11 +40,13 @@ const ArtistInfoSection = ({
         <p className='subtitle2 mt-[30px] mb-[40px]'>
           {introduction || '작가 소개가 비어있습니다.'}
         </p>
-        <FollowButton
-          initFollowState={isFollow}
-          followUserId={userId}
-          isFull={true}
-        />
+        {!isMine && (
+          <FollowButton
+            initFollowState={isFollow}
+            followUserId={userId}
+            isFull={true}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentDefault.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentDefault.tsx
@@ -24,8 +24,7 @@ const CommentDefault = ({
     deleteComment(commentId, {
       onSuccess: () => {
         queryClient.invalidateQueries({
-          predicate: (query) =>
-            query.queryKey[0] === ARTWORK.artworkPostComments(postId),
+          queryKey: [ARTWORK.artworkPostComments(postId)],
         });
 
         // 토스트 메세지로 수정

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentEdit.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentEdit.tsx
@@ -1,7 +1,9 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { ChangeEvent, useState } from 'react';
 
 import OvalButton from '@/components/Button/OvalButton';
 import Textarea from '@/components/Input/Textarea';
+import { ARTWORK } from '@/constants/API';
 import usePatchArtworkComment from '@/hooks/serverStateHooks/usePatchArtworkComment';
 import { CommentControllerProps } from '@/types/comment';
 
@@ -10,6 +12,8 @@ const CommentEdit = ({
   postId,
   setIsEditMode,
 }: CommentControllerProps) => {
+  const queryClient = useQueryClient();
+
   const { content, commentId } = comment;
 
   const { mutate: editComment } = usePatchArtworkComment();
@@ -32,6 +36,9 @@ const CommentEdit = ({
       },
       {
         onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: [ARTWORK.artworkPostComments(postId)],
+          });
           setIsEditMode(false);
 
           // 토스트 메세지 적용

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkWriteCommentSection.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkWriteCommentSection.tsx
@@ -5,7 +5,7 @@ import BasicInput from '@/components/Input/BasicInput';
 import usePostComment from '@/hooks/serverStateHooks/usePostComment';
 
 const ArtworkWriteCommentSection = ({ postId }: { postId: number }) => {
-  const { mutate: createComment } = usePostComment();
+  const { mutate: createComment } = usePostComment(postId);
 
   const [comment, setComment] = useState('');
 

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/index.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/index.tsx
@@ -8,10 +8,17 @@ import useGetArtworkComments from '@/hooks/serverStateHooks/useGetArtworkComment
 import ArtworkCommentUnit from './ArtworkCommentUnit';
 import ArtworkWriteCommentSection from './ArtworkWriteCommentSection';
 
-const ArtworkCommentSection = ({ postId }: { postId: number }) => {
+interface ArtworkCommentSectionProps {
+  postId: number;
+  commentCount: number;
+}
+
+const ArtworkCommentSection = ({
+  postId,
+  commentCount,
+}: ArtworkCommentSectionProps) => {
   const {
     commentData,
-    allCommentCount,
     isLoading,
     hasNextPage,
     lastCommentRef,
@@ -30,7 +37,7 @@ const ArtworkCommentSection = ({ postId }: { postId: number }) => {
 
   return (
     <div className='flex-1 flex flex-col gap-5'>
-      <h2>댓글 ({allCommentCount})</h2>
+      <h2>댓글 ({commentCount})</h2>
       <div className='flex flex-col gap-[30px] tablet:px-[60px] px-[10px] py-[60px] rounded-[10px] bg-gray-900'>
         <ArtworkWriteCommentSection postId={postId} />
         <div className='flex flex-col gap-[70px]'>

--- a/src/components/Card/ArtistProfileCard.tsx
+++ b/src/components/Card/ArtistProfileCard.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 
+import DefaultImage from '@/../public/images/defaultArtworkImage.png';
 import DefaultProfileImage from '@/../public/images/defaultProfileImage.png';
 import RankingLabel from '@/../public/images/rankingLabel.png';
 import { ArtistInfoType } from '@/types/artist';
@@ -43,7 +44,7 @@ const ArtistProfileCard = ({ rank, artistInfo }: ArtistProfileCardProps) => {
       </div>
 
       <Image
-        src={profileImage ?? DefaultProfileImage}
+        src={artworkImage ?? DefaultImage}
         alt={profileImage ? 'artwork image' : 'artwork default image'}
         className={profileImage ? 'object-contain' : ''}
         fill={true}
@@ -55,7 +56,13 @@ const ArtistProfileCard = ({ rank, artistInfo }: ArtistProfileCardProps) => {
       <div className='absolute left-0 bottom-0 w-full pt-10 pb-[15px] px-[30px] bg-white'>
         {/* profile thumbnail */}
         <div className='absolute left-[30px] -top-[34px] w-[69px] h-[69px] rounded-full overflow-hidden'>
-          <Image src={profileImage ?? DefaultProfileImage} alt='user-profile' />
+          <Image
+            src={profileImage ?? DefaultProfileImage}
+            alt={
+              profileImage ? 'profile image' : 'artist default profile image'
+            }
+            fill={true}
+          />
         </div>
         {/* profile info */}
         <div className='flex flex-col gap-[10px]'>

--- a/src/components/Card/ArtworkCard.tsx
+++ b/src/components/Card/ArtworkCard.tsx
@@ -1,9 +1,10 @@
 'use client';
-
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 import DefaultImage from '@/../public/images/defaultArtworkImage.png';
 import RankingLabel from '@/../public/images/rankingLabel.png';
+import ROUTE from '@/constants/routes';
 import { ArtworkInfoType } from '@/types';
 
 import Icon from '../Icon/Icon';
@@ -25,6 +26,8 @@ const ArtworkCard = ({
   rank,
   artworkInfo,
 }: ArtworkCardProps) => {
+  const router = useRouter();
+
   const {
     postId,
     title,
@@ -61,9 +64,14 @@ const ArtworkCard = ({
     'artwork-list': 'gap-[70px]',
   };
 
+  const clickArtworkCard = () => {
+    router.push(ROUTE.artworkDetail + `?postId=${postId}`);
+  };
+
   return (
     <div
-      className={`relative overflow-hidden group rounded-[5px] ${modeClasses[mode]}`}
+      className={`relative overflow-hidden group rounded-[5px] ${modeClasses[mode]} cursor-pointer`}
+      onClick={clickArtworkCard}
     >
       <Image
         src={postImage || DefaultImage}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -2,6 +2,7 @@ const ROUTE = {
   home: '/',
   signIn: '/auth/sign-in',
   signUp: '/auth/sign-up',
+  artworkDetail: '/artwork/detail',
   artworkList: '/artwork/list',
   artworkUpload: '/artwork/upload',
   collections: '/collections',

--- a/src/hooks/serverStateHooks/useGetArtworkComments.ts
+++ b/src/hooks/serverStateHooks/useGetArtworkComments.ts
@@ -22,7 +22,7 @@ const useGetArtworkComments = ({
     isFetching,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: [ARTWORK.artworkPostComments, postId],
+    queryKey: [ARTWORK.artworkPostComments(postId)],
     queryFn: ({ pageParam = 0 }) =>
       getArtworkComments({ postId, size, skip: pageParam }),
     initialPageParam: skip,

--- a/src/hooks/serverStateHooks/useGetArtworkComments.ts
+++ b/src/hooks/serverStateHooks/useGetArtworkComments.ts
@@ -1,9 +1,8 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import getArtworkComments from '@/apis/artwork/getArtworkComments';
 import { ARTWORK } from '@/constants/API';
-import { ArtworkComment } from '@/types';
 
 interface UseGetArtworkComments {
   postId: number;
@@ -37,16 +36,6 @@ const useGetArtworkComments = ({
 
   const lastCommentRef = useRef<HTMLDivElement | null>(null);
 
-  const allCommentCount = useMemo(
-    () =>
-      commentData?.pages.reduce(
-        (acc: number, cur: { comments: ArtworkComment[] }) =>
-          cur.comments.length + acc,
-        0,
-      ) || 0,
-    [commentData],
-  );
-
   const [observerActive, setObserverActive] = useState(false);
 
   const activeObserver = () => setObserverActive(true);
@@ -78,7 +67,6 @@ const useGetArtworkComments = ({
 
   return {
     commentData,
-    allCommentCount,
     isLoading,
     hasNextPage,
     lastCommentRef,

--- a/src/hooks/serverStateHooks/useGetArtworkPost.ts
+++ b/src/hooks/serverStateHooks/useGetArtworkPost.ts
@@ -58,7 +58,14 @@ const useGetArtworkPost = (postId: number | null) => {
     isMine: data.isMine,
   };
 
-  return { headerInfo, socialInfo, detailInfo, artistInfo, isLoading };
+  return {
+    headerInfo,
+    socialInfo,
+    detailInfo,
+    artistInfo,
+    isLoading,
+    commentCount: data.commentCount,
+  };
 };
 
 export default useGetArtworkPost;

--- a/src/hooks/serverStateHooks/useGetArtworkPost.ts
+++ b/src/hooks/serverStateHooks/useGetArtworkPost.ts
@@ -55,6 +55,7 @@ const useGetArtworkPost = (postId: number | null) => {
     userField: data.userField,
     isFollow: data.isFollow,
     introduction: data.introduction,
+    isMine: data.isMine,
   };
 
   return { headerInfo, socialInfo, detailInfo, artistInfo, isLoading };

--- a/src/hooks/serverStateHooks/usePostComment.ts
+++ b/src/hooks/serverStateHooks/usePostComment.ts
@@ -1,4 +1,6 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { ARTWORK } from '@/constants/API';
 
 import postComment from '../../apis/artwork/postComment';
 
@@ -7,11 +9,16 @@ interface MutateProps {
   content: string;
 }
 
-const usePostComment = () => {
+const usePostComment = (postId: number) => {
+  const queryClient = useQueryClient();
+
   const { mutate } = useMutation({
     mutationFn: ({ postId, content }: MutateProps) =>
       postComment({ postId, content }),
     onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [ARTWORK.artworkPostComments(postId)],
+      });
       alert('댓글 생성 성공');
     },
   });

--- a/src/types/artwork.ts
+++ b/src/types/artwork.ts
@@ -86,6 +86,7 @@ export interface ArtworkPostArtistInfoType
     | 'userField'
     | 'isFollow'
     | 'introduction'
+    | 'isMine'
   > {}
 
 export interface ArtworkComment {

--- a/src/utils/timeFormatter.ts
+++ b/src/utils/timeFormatter.ts
@@ -14,11 +14,15 @@ const timeFormatter = (timeString: string) => {
   const nowSeconds = now.getUTCSeconds();
 
   if (nowYear !== year || nowMonth !== month || nowDate !== date)
-    return [
-      year,
-      month > 10 ? month : `0${month}`,
-      date > 10 ? date : `0${date}`,
-    ].join('.');
+    return new Date(timeString + 'Z').toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul', // 한국 시간대 설정
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
 
   if (nowHour !== hour) return `${nowHour - hour}시간 전`;
 

--- a/src/utils/timeFormatter.ts
+++ b/src/utils/timeFormatter.ts
@@ -15,7 +15,7 @@ const timeFormatter = (timeString: string) => {
 
   if (nowYear !== year || nowMonth !== month || nowDate !== date)
     return new Date(timeString + 'Z').toLocaleString('ko-KR', {
-      timeZone: 'Asia/Seoul', // 한국 시간대 설정
+      timeZone: 'Asia/Seoul',
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',


### PR DESCRIPTION
🚨 제목: [TASK-ID] 라벨: 기능명
  ex. [TASK-11] feat: 로그인 페이지 구현 (확인 후 지워주세요)

## 📝 작업 내용
- [x] 작품 카드 클릭시 작품 상세 페이지로 이동
- [x] 본인 작품에도 팔로우 버튼이 나오는 현상 수정
- [x] 작가 카드 내 대표 작품 이미지가 작가 프로필 사진으로 보이는 현상 수정
- [x] 업로드 시간대를 대한민국 시간대에 맞게 시간대 포멧 수정
- [x] 댓글 개수에 사용되는 데이터 변경
- [x]  댓글 생성/수정/삭제 시 다시 댓글 조회 되도록 invalidateQueries 로직 추가

## 📸 스크린샷

## 💬 리뷰 요구사항