### PR TITLE
[TASK-99] feat: 프로필 페이지 상단 작가 정보 조회 영역 추가

### DIFF
--- a/src/apis/follow/getFollowerList.ts
+++ b/src/apis/follow/getFollowerList.ts
@@ -1,0 +1,18 @@
+import { USER } from '@/constants/API';
+import { FollowUser } from '@/types/user';
+import TokenHandler from '@/utils/tokenHandler';
+
+import defaultClient, { authorizedClient } from '..';
+
+const getFollowerList = async (userId: number) => {
+  const currentClient =
+    TokenHandler.getAccessToken() !== '' ? authorizedClient : defaultClient;
+
+  const { data } = await currentClient.get<{ users: FollowUser[] }>(
+    USER.followerList(userId),
+  );
+
+  return data;
+};
+
+export default getFollowerList;

--- a/src/apis/follow/getFollowerList.ts
+++ b/src/apis/follow/getFollowerList.ts
@@ -1,5 +1,5 @@
 import { USER } from '@/constants/API';
-import { FollowUser } from '@/types/user';
+import { FollowUserType } from '@/types/user';
 import TokenHandler from '@/utils/tokenHandler';
 
 import defaultClient, { authorizedClient } from '..';
@@ -8,7 +8,7 @@ const getFollowerList = async (userId: number) => {
   const currentClient =
     TokenHandler.getAccessToken() !== '' ? authorizedClient : defaultClient;
 
-  const { data } = await currentClient.get<{ users: FollowUser[] }>(
+  const { data } = await currentClient.get<{ users: FollowUserType[] }>(
     USER.followerList(userId),
   );
 

--- a/src/apis/follow/getFollowingList.tsx
+++ b/src/apis/follow/getFollowingList.tsx
@@ -1,5 +1,5 @@
 import { USER } from '@/constants/API';
-import { FollowUser } from '@/types/user';
+import { FollowUserType } from '@/types/user';
 import TokenHandler from '@/utils/tokenHandler';
 
 import defaultClient, { authorizedClient } from '..';
@@ -8,7 +8,7 @@ const getFollowingList = async (userId: number) => {
   const currentClient =
     TokenHandler.getAccessToken() !== '' ? authorizedClient : defaultClient;
 
-  const { data } = await currentClient.get<{ users: FollowUser[] }>(
+  const { data } = await currentClient.get<{ users: FollowUserType[] }>(
     USER.followingList(userId),
   );
 

--- a/src/apis/follow/getFollowingList.tsx
+++ b/src/apis/follow/getFollowingList.tsx
@@ -1,0 +1,18 @@
+import { USER } from '@/constants/API';
+import { FollowUser } from '@/types/user';
+import TokenHandler from '@/utils/tokenHandler';
+
+import defaultClient, { authorizedClient } from '..';
+
+const getFollowingList = async (userId: number) => {
+  const currentClient =
+    TokenHandler.getAccessToken() !== '' ? authorizedClient : defaultClient;
+
+  const { data } = await currentClient.get<{ users: FollowUser[] }>(
+    USER.followingList(userId),
+  );
+
+  return data;
+};
+
+export default getFollowingList;

--- a/src/apis/image/postImage.ts
+++ b/src/apis/image/postImage.ts
@@ -68,7 +68,6 @@ export const putNotifyImageUploadComplete = async (imageId: number) => {
 
     if (response.status !== 204) {
       throw new Error('이미지 업로드 완료에 실패하였습니다.');
-      return false;
     } else {
       return true;
     }

--- a/src/apis/image/postImage.ts
+++ b/src/apis/image/postImage.ts
@@ -68,6 +68,9 @@ export const putNotifyImageUploadComplete = async (imageId: number) => {
 
     if (response.status !== 204) {
       throw new Error('이미지 업로드 완료에 실패하였습니다.');
+      return false;
+    } else {
+      return true;
     }
   } catch (error) {
     console.error('서버에 업로드 완료 알림 실패: ', error);

--- a/src/apis/user/patchProfileInfo.ts
+++ b/src/apis/user/patchProfileInfo.ts
@@ -1,0 +1,43 @@
+import { isAxiosError } from 'axios';
+
+import { USER } from '@/constants/API';
+import {
+  COMMON_ERROR_MESSAGE,
+  EDIT_USER_PROFILE_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { ErrorResponseType } from '@/types/errorResponse';
+import { UpdateProfileType } from '@/types/user';
+
+import { authorizedClient } from '..';
+
+const patchProfileInfo = async (updateInfo: UpdateProfileType) => {
+  try {
+    const response = await authorizedClient.patch<null>(USER.userProfile, {
+      ...updateInfo,
+    });
+
+    if (response.status === 204) {
+      return true;
+    } else {
+      throw new Error('프로필 수정 실패');
+    }
+    return false;
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        console.error(EDIT_USER_PROFILE_ERROR_MESSAGE[code]);
+        throw new Error(EDIT_USER_PROFILE_ERROR_MESSAGE[code]);
+      } else {
+        console.error(EDIT_USER_PROFILE_ERROR_MESSAGE.UNKNOWN_ERROR);
+        throw new Error(EDIT_USER_PROFILE_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+  }
+};
+
+export default patchProfileInfo;

--- a/src/apis/user/patchProfileInfo.ts
+++ b/src/apis/user/patchProfileInfo.ts
@@ -16,12 +16,11 @@ const patchProfileInfo = async (updateInfo: UpdateProfileType) => {
       ...updateInfo,
     });
 
-    if (response.status === 204) {
-      return true;
-    } else {
+    if (response.status !== 204) {
       throw new Error('프로필 수정 실패');
     }
-    return false;
+
+    return true;
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;

--- a/src/apis/user/patchProfileInfo.ts
+++ b/src/apis/user/patchProfileInfo.ts
@@ -12,9 +12,10 @@ import { authorizedClient } from '..';
 
 const patchProfileInfo = async (updateInfo: UpdateProfileType) => {
   try {
-    const response = await authorizedClient.patch<null>(USER.userProfile, {
-      ...updateInfo,
-    });
+    const response = await authorizedClient.patch<null>(
+      USER.userProfile,
+      updateInfo,
+    );
 
     if (response.status !== 204) {
       throw new Error('프로필 수정 실패');

--- a/src/apis/user/updateProfileInfo.ts
+++ b/src/apis/user/updateProfileInfo.ts
@@ -1,0 +1,50 @@
+import {
+  postPresignedUrl,
+  putNotifyImageUploadComplete,
+  putUploadImageToS3,
+} from '@/apis/image/postImage';
+import patchProfileInfo from '@/apis/user/patchProfileInfo';
+import { UpdateProfileType, UserStringProfileType } from '@/types/user';
+
+export interface UpdateProfileInfoProps {
+  imageFile?: File;
+  updateInfo: UserStringProfileType;
+}
+
+const uploadProfileImage = async (imageFile: File): Promise<number> => {
+  const presignedData = await postPresignedUrl({
+    fileSize: imageFile.size,
+    fileType: imageFile.type,
+  });
+
+  if (!presignedData) throw new Error('Presigned URL 요청 실패');
+
+  const { presignedUrl, imageId } = presignedData;
+
+  const uploadSuccess = await putUploadImageToS3({
+    file: imageFile,
+    uploadUrl: presignedUrl,
+  });
+
+  if (!uploadSuccess) throw new Error('이미지 업로드 실패');
+
+  await putNotifyImageUploadComplete(imageId);
+
+  return imageId;
+};
+
+const updateProfileInfo = async ({
+  imageFile,
+  updateInfo,
+}: UpdateProfileInfoProps) => {
+  const newProfile = { ...updateInfo } as UpdateProfileType;
+
+  if (imageFile) {
+    const imageId = await uploadProfileImage(imageFile);
+    newProfile.profileImage = imageId;
+  }
+
+  return patchProfileInfo(newProfile);
+};
+
+export default updateProfileInfo;

--- a/src/app/auth/(authWithLayout)/sign-in/page.tsx
+++ b/src/app/auth/(authWithLayout)/sign-in/page.tsx
@@ -47,8 +47,8 @@ const SignInPage = () => {
           className='w-full flex flex-col gap-[60px]'
         >
           <div className='flex flex-col gap-[30px]'>
-            <EmailInput mode={'sign-in'} />
-            <PasswordInput mode={'sign-in'} />
+            <EmailInput mode='sign-in' />
+            <PasswordInput mode='sign-in' />
           </div>
           <SquareButtonL
             type='submit'

--- a/src/app/auth/(authWithLayout)/sign-up/page.tsx
+++ b/src/app/auth/(authWithLayout)/sign-up/page.tsx
@@ -98,8 +98,8 @@ const SignUpPage = () => {
           className='w-full flex flex-col gap-[60px]'
         >
           <div className='flex flex-col gap-[30px]'>
-            <EmailInput mode={'sign-up'} />
-            <PasswordInput mode={'sign-up'} />
+            <EmailInput mode='sign-up' />
+            <PasswordInput mode='sign-up' />
             <NicknameInput />
           </div>
           <SquareButtonL

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -16,7 +16,7 @@ const ProfilePage = () => {
   if (isLoading) return <div>Loading</div>;
 
   return (
-    <div className='flex flex-col flex-grow gap-[70px] w-full max-w-[1920px] m-auto py-[70px] tablet:px-[140px] px-[32px]'>
+    <div className='flex flex-col flex-grow gap-[70px] w-full max-w-[1920px] m-auto py-[70px] px-[32px]'>
       <UserInfoSection userInfo={userInfo} />
       <UserArtworkSection isMine={userInfo.isMine} />
     </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+import UserInfoSection from '@/components/ProfilePage/UserInfoSection';
+import useGetProfileInfo from '@/hooks/serverStateHooks/useGetProfileInfo';
+
+import UserArtworkSection from '../../components/ProfilePage/UserArtworkSection';
+
+const ProfilePage = () => {
+  const searchParams = useSearchParams();
+  const userIdParam = searchParams.get('userId');
+  const userId = userIdParam ? Number(userIdParam) : null;
+  const { userInfo, isLoading } = useGetProfileInfo(userId);
+
+  if (isLoading) return <div>Loading</div>;
+
+  return (
+    <div className='flex flex-col flex-grow gap-[70px] w-full max-w-[1920px] m-auto py-[70px] tablet:px-[140px] px-[32px]'>
+      <UserInfoSection userInfo={userInfo} />
+      <UserArtworkSection isMine={userInfo.isMine} />
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentEdit.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentEdit.tsx
@@ -58,8 +58,8 @@ const CommentEdit = ({
       <div className='flex justify-end gap-2.5'>
         <OvalButton
           disabled={commentText.length === 0}
-          buttonSize={'s'}
-          variant={'primary'}
+          buttonSize='s'
+          variant='primary'
           className='!bg-gray-900'
           onClick={cancelEditMode}
         >
@@ -67,8 +67,8 @@ const CommentEdit = ({
         </OvalButton>
         <OvalButton
           disabled={commentText.length === 0}
-          buttonSize={'s'}
-          variant={'primary'}
+          buttonSize='s'
+          variant='primary'
           onClick={clickEditButton}
         >
           <p className='button-s'>완료</p>

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/index.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/index.tsx
@@ -24,7 +24,7 @@ const ArtworkCommentUnit = ({
     <div className='flex items-start gap-[29px]' ref={ref}>
       <Image
         src={profileImage || '/images/defaultProfileImage.png'}
-        alt={'artwork default image'}
+        alt='artwork default image'
         className='rounded-full'
         width={56}
         height={56}

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkWriteCommentSection.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkWriteCommentSection.tsx
@@ -26,7 +26,7 @@ const ArtworkWriteCommentSection = ({ postId }: { postId: number }) => {
         commentBackground={true}
       />
       <span className='h-[60px]'>
-        <SquareButtonL variant={'tertiary'} onClick={submitComment}>
+        <SquareButtonL variant='tertiary' onClick={submitComment}>
           댓글 작성
         </SquareButtonL>
       </span>

--- a/src/components/Button/OvalButton.tsx
+++ b/src/components/Button/OvalButton.tsx
@@ -1,6 +1,7 @@
 import { OvalButtonProps } from '@/types';
 
 const OvalButton = ({
+  type = 'button',
   variant = 'primary',
   buttonSize,
   children,
@@ -41,12 +42,13 @@ const OvalButton = ({
       className={`
         flex items-center justify-center rounded-full gap-[10px]
         transition-all duration-300 ease-in-out active:scale-95
-        ${bgColorClasses[variant]}
-        ${hoverBgColorClasses[variant]}
-        ${textColorClasses[variant]}
+        ${disabled ? bgColorClasses['secondary'] : bgColorClasses[variant]} 
+        ${disabled ? 'cursor-not-allowed' : hoverBgColorClasses[variant]}
+        ${disabled ? textColorClasses['secondary'] : textColorClasses[variant]} 
         ${buttonSizeClasses[buttonSize]}
         ${className}
       `}
+      type={type}
     >
       {buttonSize === 'm' ? (
         <h4>{children}</h4>

--- a/src/components/Card/ArtworkAndCollectionCard/index.tsx
+++ b/src/components/Card/ArtworkAndCollectionCard/index.tsx
@@ -52,7 +52,7 @@ const ArtworkAndCollectionCard = ({
 
   return (
     <div
-      className='relative overflow-hidden group rounded-[5px] w-full min-h-[224px] mobile:min-h-[511px] cursor-pointer'
+      className='relative overflow-hidden group rounded-[5px] w-full aspect-[4/5] cursor-pointer'
       onClick={clickArtwork}
     >
       {artworkInfo && (

--- a/src/components/Icon/icons/EditPencil.tsx
+++ b/src/components/Icon/icons/EditPencil.tsx
@@ -10,7 +10,7 @@ const EditPencil = ({ className }: IconProps) => {
     >
       <path
         d='M15 26.2031H25.5M18.2812 7.17187L22.875 11.1094M6.46875 18.9844L19.4093 5.59187C20.8026 4.19854 23.0617 4.19854 24.455 5.59187C25.8483 6.9852 25.8483 9.24423 24.455 10.6376L11.0625 23.5781L4.5 25.5469L6.46875 18.9844Z'
-        stroke='currentColor'
+        stroke='inherit'
         strokeWidth='2.1875'
         strokeLinecap='round'
         strokeLinejoin='round'

--- a/src/components/Icon/icons/EditPencil.tsx
+++ b/src/components/Icon/icons/EditPencil.tsx
@@ -10,7 +10,7 @@ const EditPencil = ({ className }: IconProps) => {
     >
       <path
         d='M15 26.2031H25.5M18.2812 7.17187L22.875 11.1094M6.46875 18.9844L19.4093 5.59187C20.8026 4.19854 23.0617 4.19854 24.455 5.59187C25.8483 6.9852 25.8483 9.24423 24.455 10.6376L11.0625 23.5781L4.5 25.5469L6.46875 18.9844Z'
-        stroke='inherit'
+        stroke='currentColor'
         strokeWidth='2.1875'
         strokeLinecap='round'
         strokeLinejoin='round'

--- a/src/components/Input/BasicInput.tsx
+++ b/src/components/Input/BasicInput.tsx
@@ -23,6 +23,7 @@ interface BasicInputProps {
   maxLength?: number;
   errorMessage?: string;
   successMessage?: string;
+  className?: string;
 }
 
 const BasicInput = ({
@@ -41,6 +42,7 @@ const BasicInput = ({
   maxLength,
   errorMessage,
   successMessage,
+  className,
 }: BasicInputProps) => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
@@ -56,7 +58,7 @@ const BasicInput = ({
         : 'text-white';
 
   return (
-    <div>
+    <div className={className}>
       <Input
         type={showEyeIcon && isPasswordVisible ? 'text' : type || 'text'}
         label={label}

--- a/src/components/Modal/CreateCollectionModal.tsx
+++ b/src/components/Modal/CreateCollectionModal.tsx
@@ -55,7 +55,7 @@ const CreateCollectionModal = () => {
         />
         <span className='h-[60px] mt-[23px]'>
           <SquareButtonL
-            variant={'primary'}
+            variant='primary'
             onClick={clickCreateButton}
             disabled={collectionName.length === 0}
           >

--- a/src/components/Modal/FollowInfoModal/FollowUserUnit.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowUserUnit.tsx
@@ -1,0 +1,57 @@
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { useStore } from 'zustand';
+
+import DefaultProfile from '@/../public/images/defaultProfileImage.png';
+import FollowButton from '@/components/Button/FollowButton';
+import ROUTE from '@/constants/routes';
+import modalStore from '@/stores/modalStore';
+
+interface FollowUserUnitProps {
+  userId: number;
+  profileImage: string;
+  nickname: string;
+  introduction: string;
+  followStatus: boolean;
+}
+
+const FollowUserUnit = ({
+  userId,
+  profileImage,
+  nickname,
+  introduction,
+  followStatus,
+}: FollowUserUnitProps) => {
+  const router = useRouter();
+  const { closeModal } = useStore(modalStore);
+
+  const moveToProfilePage = () => {
+    router.push(ROUTE.profile(userId));
+    closeModal();
+  };
+
+  return (
+    <div className='flex justify-between items-center py-[27px] tablet:py-[18px] tablet:pr-[45px]'>
+      <button
+        type='button'
+        className='group flex gap-[33px] tablet:gap-[53px] items-center'
+        onClick={moveToProfilePage}
+      >
+        <Image
+          src={profileImage || DefaultProfile}
+          alt={profileImage ? 'user-profile-image' : 'default-profile'}
+          className='rounded-full w-14 tablet:w-[94px] h-14 tablet:h-[94px]'
+        />
+        <div>
+          <p className='placeholder text-white mb-[4px] group-hover:underline'>
+            {nickname}
+          </p>
+          <p className='button-s text-gray-500'>{introduction}fdsfafsdfas</p>
+        </div>
+      </button>
+      <FollowButton initFollowState={followStatus} followUserId={userId} />
+    </div>
+  );
+};
+
+export default FollowUserUnit;

--- a/src/components/Modal/FollowInfoModal/FollowUserUnit.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowUserUnit.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useStore } from 'zustand';
 
-import DefaultProfile from '@/../public/images/defaultProfileImage.png';
 import FollowButton from '@/components/Button/FollowButton';
 import ROUTE from '@/constants/routes';
 import modalStore from '@/stores/modalStore';
@@ -38,11 +37,13 @@ const FollowUserUnit = ({
         onClick={moveToProfilePage}
       >
         <Image
-          src={profileImage || DefaultProfile}
+          src={profileImage || '/images/defaultProfileImage.png'}
           alt={profileImage ? 'user-profile-image' : 'default-profile'}
-          className='rounded-full w-14 tablet:w-[94px] h-14 tablet:h-[94px]'
+          className='rounded-full tablet:w-[94px] h-14 tablet:h-[94px]'
+          width={56}
+          height={56}
         />
-        <div>
+        <div className='text-start'>
           <p className='placeholder text-white mb-[4px] group-hover:underline'>
             {nickname}
           </p>

--- a/src/components/Modal/FollowInfoModal/FollowerList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowerList.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import FollowUserUnit from '@/components/Modal/FollowInfoModal/FollowUserUnit';
+import useGetFollowerList from '@/hooks/serverStateHooks/useGetFollowerList';
+
+const FollowerList = ({ nickname }: { nickname: string }) => {
+  const { followerList, isLoading } = useGetFollowerList();
+
+  if (isLoading) return <div>isLoading</div>;
+
+  return (
+    <div className='pr-[26px] tablet:pr-[45px]'>
+      {followerList.length === 0 ? (
+        <div className='button-l w-full h-[900px] tablet:pr-[58px] text-center leading-[900px] pb-[45px] text-white'>
+          팔로우한 작가가 없습니다.
+        </div>
+      ) : (
+        <>
+          <p className='button-m text-white mt-[25px] mb-[55px]'>
+            <span className='hidden tablet:block'>{nickname} 님의</span>
+            {`팔로워 ${followerList.length}`}
+          </p>
+          <div className='h-[900px] pb-[46px] overflow-auto scroll-hide'>
+            {followerList.map((follower) => (
+              <FollowUserUnit
+                key={follower.userId}
+                followStatus={false}
+                {...follower}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FollowerList;

--- a/src/components/Modal/FollowInfoModal/FollowerList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowerList.tsx
@@ -3,7 +3,7 @@
 import FollowUserUnit from '@/components/Modal/FollowInfoModal/FollowUserUnit';
 import useGetFollowerList from '@/hooks/serverStateHooks/useGetFollowerList';
 
-const FollowerList = (nickname: string) => {
+const FollowerList = ({ nickname }: { nickname: string }) => {
   const { followerList, isLoading } = useGetFollowerList();
 
   if (isLoading) return <div>isLoading</div>;
@@ -26,7 +26,7 @@ const FollowerList = (nickname: string) => {
             {followerList.map((follower) => (
               <FollowUserUnit
                 key={follower.userId}
-                followStatus={false}
+                followStatus={follower.isFollow}
                 {...follower}
               />
             ))}

--- a/src/components/Modal/FollowInfoModal/FollowerList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowerList.tsx
@@ -3,7 +3,7 @@
 import FollowUserUnit from '@/components/Modal/FollowInfoModal/FollowUserUnit';
 import useGetFollowerList from '@/hooks/serverStateHooks/useGetFollowerList';
 
-const FollowerList = ({ nickname }: { nickname: string }) => {
+const FollowerList = (nickname: string) => {
   const { followerList, isLoading } = useGetFollowerList();
 
   if (isLoading) return <div>isLoading</div>;

--- a/src/components/Modal/FollowInfoModal/FollowerList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowerList.tsx
@@ -9,18 +9,20 @@ const FollowerList = ({ nickname }: { nickname: string }) => {
   if (isLoading) return <div>isLoading</div>;
 
   return (
-    <div className='pr-[26px] tablet:pr-[45px]'>
+    <>
       {followerList.length === 0 ? (
-        <div className='button-l w-full h-[900px] tablet:pr-[58px] text-center leading-[900px] pb-[45px] text-white'>
+        <div className='button-l w-full tablet:pr-[58px] text-center pb-[45px] text-white'>
           팔로우한 작가가 없습니다.
         </div>
       ) : (
         <>
           <p className='button-m text-white mt-[25px] mb-[55px]'>
-            <span className='hidden tablet:block'>{nickname} 님의</span>
+            <span className='hidden tablet:inline-block mr-2.5'>
+              {nickname} 님의
+            </span>
             {`팔로워 ${followerList.length}`}
           </p>
-          <div className='h-[900px] pb-[46px] overflow-auto scroll-hide'>
+          <div className='flex-1 overflow-auto scroll-hide'>
             {followerList.map((follower) => (
               <FollowUserUnit
                 key={follower.userId}
@@ -31,7 +33,7 @@ const FollowerList = ({ nickname }: { nickname: string }) => {
           </div>
         </>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/components/Modal/FollowInfoModal/FollowingList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowingList.tsx
@@ -10,18 +10,20 @@ const FollowingList = ({ nickname }: { nickname: string }) => {
   if (isLoading) return <div>Loading...</div>;
 
   return (
-    <div className='pr-[26px] tablet:pr-[45px]'>
+    <>
       {followingList.length === 0 ? (
-        <div className='button-l w-full h-[900px] tablet:pr-[58px] text-center leading-[900px] pb-[45px] text-white'>
+        <div className='button-l w-full tablet:pr-[58px] text-center pb-[45px] text-white'>
           팔로잉한 작가가 없습니다.
         </div>
       ) : (
         <>
           <p className='button-m text-white mt-[25px] mb-[55px]'>
-            <span className='hidden tablet:block'>{nickname} 님의</span>
+            <span className='hidden tablet:inline-block mr-2.5'>
+              {nickname} 님의
+            </span>
             {`팔로잉 ${followingList.length}`}
           </p>
-          <div className='h-[900px] pb-[46px] overflow-auto scroll-hide'>
+          <div className='flex-1 overflow-auto scroll-hide'>
             {followingList.map((following) => (
               <FollowUserUnit
                 key={following.userId}
@@ -32,7 +34,7 @@ const FollowingList = ({ nickname }: { nickname: string }) => {
           </div>
         </>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/components/Modal/FollowInfoModal/FollowingList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowingList.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import useGetFollowingList from '@/hooks/serverStateHooks/useGetFollowingList';
+
+import FollowUserUnit from './FollowUserUnit';
+
+const FollowingList = ({ nickname }: { nickname: string }) => {
+  const { followingList, isLoading } = useGetFollowingList();
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return (
+    <div className='pr-[26px] tablet:pr-[45px]'>
+      {followingList.length === 0 ? (
+        <div className='button-l w-full h-[900px] tablet:pr-[58px] text-center leading-[900px] pb-[45px] text-white'>
+          팔로잉한 작가가 없습니다.
+        </div>
+      ) : (
+        <>
+          <p className='button-m text-white mt-[25px] mb-[55px]'>
+            <span className='hidden tablet:block'>{nickname} 님의</span>
+            {`팔로잉 ${followingList.length}`}
+          </p>
+          <div className='h-[900px] pb-[46px] overflow-auto scroll-hide'>
+            {followingList.map((following) => (
+              <FollowUserUnit
+                key={following.userId}
+                followStatus={false}
+                {...following}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FollowingList;

--- a/src/components/Modal/FollowInfoModal/FollowingList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowingList.tsx
@@ -13,7 +13,7 @@ const FollowingList = ({ nickname }: { nickname: string }) => {
     <>
       {followingList.length === 0 ? (
         <div className='button-l w-full tablet:pr-[58px] text-center pb-[45px] text-white'>
-          팔로잉한 작가가 없습니다.
+          팔로우한 작가가 없습니다.
         </div>
       ) : (
         <>

--- a/src/components/Modal/FollowInfoModal/FollowingList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowingList.tsx
@@ -27,7 +27,7 @@ const FollowingList = ({ nickname }: { nickname: string }) => {
             {followingList.map((following) => (
               <FollowUserUnit
                 key={following.userId}
-                followStatus={false}
+                followStatus={following.isFollow}
                 {...following}
               />
             ))}

--- a/src/components/Modal/FollowInfoModal/TransitionToggle.tsx
+++ b/src/components/Modal/FollowInfoModal/TransitionToggle.tsx
@@ -1,0 +1,81 @@
+import '@/styles/shadow.css';
+
+import { Dispatch, SetStateAction } from 'react';
+import { useStore } from 'zustand';
+
+import Icon from '@/components/Icon/Icon';
+import modalStore from '@/stores/modalStore';
+
+interface TransitionToggleProps {
+  followType: 'follower' | 'following';
+  setFollowType: Dispatch<SetStateAction<'follower' | 'following'>>;
+}
+
+const TransitionToggle = ({
+  followType,
+  setFollowType,
+}: TransitionToggleProps) => {
+  const { closeModal } = useStore(modalStore);
+
+  const selectedTabClassName =
+    'absolute inset-0 bg-background-overlay transition-transform duration-500 ease-in-out';
+  const defaultTabClassName =
+    'flex-1 px-5 py-2.5 rounded-[10px] relative overflow-hidden text-gray-500';
+
+  const clickTabButton = (value: 'follower' | 'following') => {
+    if (value !== followType) setFollowType(value);
+  };
+
+  return (
+    <div className='tablet:pr-[103px]'>
+      <div className='flex gap-3 w-[223px] tablet:w-[282px] m-auto p-2.5 rounded-2xl bg-gray-900 text-gray-500'>
+        <button
+          type='button'
+          onClick={() => clickTabButton('follower')}
+          className={`
+            ${defaultTabClassName}
+            ${followType === 'follower' ? 'text-white' : ''}
+          `}
+        >
+          <span
+            className={`
+              ${selectedTabClassName}
+              ${followType === 'follower' ? 'translate-x-0' : 'translate-x-full'}
+            `}
+          ></span>
+          <span className='relative z-10'>팔로워</span>
+        </button>
+
+        <button
+          type='button'
+          onClick={() => clickTabButton('following')}
+          className={`
+            ${defaultTabClassName}
+            ${followType === 'following' ? 'text-white' : ''}
+          `}
+        >
+          <span
+            className={`
+              ${selectedTabClassName}
+              ${followType === 'following' ? 'translate-x-0' : '-translate-x-full'}
+            `}
+          ></span>
+          <span className='relative z-10'>팔로잉</span>
+        </button>
+      </div>
+      <Icon
+        name='Close'
+        size='l'
+        className='absolute top-[45px] right-[45px] text-gray-500 hidden tablet:block'
+        onClick={closeModal}
+      />
+      <Icon
+        name='Close'
+        size='m'
+        className='absolute top-[23px] right-[23px] text-gray-500 tablet:hidden'
+        onClick={closeModal}
+      />
+    </div>
+  );
+};
+export default TransitionToggle;

--- a/src/components/Modal/FollowInfoModal/TransitionToggle.tsx
+++ b/src/components/Modal/FollowInfoModal/TransitionToggle.tsx
@@ -27,7 +27,7 @@ const TransitionToggle = ({
   };
 
   return (
-    <div className='tablet:pr-[103px]'>
+    <div>
       <div className='flex gap-3 w-[223px] tablet:w-[282px] m-auto p-2.5 rounded-2xl bg-gray-900 text-gray-500'>
         <button
           type='button'

--- a/src/components/Modal/FollowInfoModal/index.tsx
+++ b/src/components/Modal/FollowInfoModal/index.tsx
@@ -15,9 +15,9 @@ const FollowInfoModal = ({ type, nickname }: FollowInfoModalProps) => {
   const [followType, setFollowType] = useState<'follower' | 'following'>(type);
 
   return (
-    <div className='relative flex flex-col gap-[25px] py-[23px] tablet:pt-[46px]'>
+    <div className='relative flex flex-col gap-[25px] h-[800px] py-[23px] tablet:pt-[46px]'>
       <TransitionToggle followType={followType} setFollowType={setFollowType} />
-      <div className='pl-[26px] tablet:pl-[103px]'>
+      <div className='flex-1 flex flex-col justify-center pl-[26px] pr-[26px] tablet:pl-[103px] tablet:pr-[45px] overflow-scroll'>
         {followType === 'follower' ? (
           <FollowerList nickname={nickname} />
         ) : (

--- a/src/components/Modal/FollowInfoModal/index.tsx
+++ b/src/components/Modal/FollowInfoModal/index.tsx
@@ -1,0 +1,31 @@
+import '@/styles/scroll.css';
+
+import { useState } from 'react';
+
+import FollowerList from './FollowerList';
+import FollowingList from './FollowingList';
+import TransitionToggle from './TransitionToggle';
+
+interface FollowInfoModalProps {
+  type: 'follower' | 'following';
+  nickname: string;
+}
+
+const FollowInfoModal = ({ type, nickname }: FollowInfoModalProps) => {
+  const [followType, setFollowType] = useState<'follower' | 'following'>(type);
+
+  return (
+    <div className='relative flex flex-col gap-[25px] py-[23px] tablet:pt-[46px]'>
+      <TransitionToggle followType={followType} setFollowType={setFollowType} />
+      <div className='pl-[26px] tablet:pl-[103px]'>
+        {followType === 'follower' ? (
+          <FollowerList nickname={nickname} />
+        ) : (
+          <FollowingList nickname={nickname} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FollowInfoModal;

--- a/src/components/ProfilePage/UserArtworkSection/ArtworkTab.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/ArtworkTab.tsx
@@ -44,7 +44,7 @@ const ArtworkTab = () => {
   };
 
   return (
-    <div className='flex flex-col items-end'>
+    <div className='flex flex-col gap-[70px] items-end'>
       <SortDropdown
         options={SORT_OPTIONS}
         selected={currentSort}

--- a/src/components/ProfilePage/UserArtworkSection/CollectionTab.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/CollectionTab.tsx
@@ -45,7 +45,7 @@ const CollectionTab = () => {
   };
 
   return (
-    <div className='pt-[50px] px-[32px] md:px-[140px]'>
+    <div className='pt-[50px]'>
       <div className='flex justify-between items-center'>
         <button className='button-m' onClick={handleCreateCollection}>
           <Icon name='Plus' size='m' className='mr-[10px]' />

--- a/src/components/ProfilePage/UserArtworkSection/ContentTabs.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/ContentTabs.tsx
@@ -68,7 +68,7 @@ const ContentTabs = ({
               key={option}
               type='button'
               value={option}
-              className={`flex-1 px-2.5 pb-2.5 relative z-10 ${
+              className={`flex-1 px-2.5 pb-2.5 ${
                 currentTab === option ? 'text-white' : 'text-gray-500'
               }`}
               onClick={changeTab}

--- a/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
@@ -63,12 +63,14 @@ const DefaultUserInfo = ({
           )}
         </div>
         <div className='relative flex-1 flex flex-col items-center mobile:items-start'>
-          <h3 className='mb-[43px] mobile:mb-[29px]'>{nickname}</h3>
+          <h3 className='mb-[43px] mobile:mb-[29px] text-[22px] mobile:text-2xl'>
+            {nickname}
+          </h3>
           <div className='mb-10'>
-            <p className='subtitle1 mb-[15px] mobile:mb-[25px] text-center mobile:text-start'>
+            <p className='subtitle2 mobile:subtitle1 mb-[15px] mobile:mb-[25px] text-center mobile:text-start'>
               {userField || '없음'}
             </p>
-            <p className='subtitle2'>{introduction}</p>
+            <p className='placeholder tablet:subtitle2'>{introduction}</p>
             {isMine && (
               <OvalButton
                 buttonSize='s'
@@ -80,7 +82,7 @@ const DefaultUserInfo = ({
               </OvalButton>
             )}
           </div>
-          <div className='static tablet:absolute top-0 right-0 flex gap-10'>
+          <div className='button-s tablet:button-m static tablet:absolute top-0 right-0 flex gap-10'>
             <button
               type='button'
               className={

--- a/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
@@ -1,0 +1,116 @@
+import Image from 'next/image';
+import { useStore } from 'zustand';
+
+import DefaultProfile from '@/../public/images/defaultProfileImage.png';
+import FollowButton from '@/components/Button/FollowButton';
+import OvalButton from '@/components/Button/OvalButton';
+import FollowInfoModal from '@/components/Modal/FollowInfoModal';
+import modalStore from '@/stores/modalStore';
+import { UserType } from '@/types/user';
+
+interface DefaultUserInfoProps extends UserType {
+  changeMode: () => void;
+}
+
+const DefaultUserInfo = ({
+  changeMode,
+  userId,
+  profileImage,
+  nickname,
+  isMine,
+  isFollow,
+  userField,
+  introduction,
+  followerCount,
+  followingCount,
+}: DefaultUserInfoProps) => {
+  const { openModal } = useStore(modalStore);
+
+  const clickFollowInfo = (type: 'follower' | 'following') => {
+    openModal({
+      modalSize: 'lg',
+      contents: <FollowInfoModal type={type} nickname={nickname} />,
+    });
+  };
+
+  return (
+    <div>
+      <div className='relative flex flex-col mobile:flex-row mobile:gap-[95px] gap-[30px] items-center mobile:items-start'>
+        <div className='w-[141px]'>
+          <Image
+            src={profileImage || DefaultProfile}
+            alt={profileImage ? 'user-profile-image' : 'default-profile'}
+            className={'rounded-full mb-[30px] mobile:mb-[40px]'}
+            width={141}
+            height={141}
+          />
+          {isMine ? (
+            <OvalButton
+              buttonSize='s'
+              variant='primary'
+              onClick={changeMode}
+              className='w-full mobile:block hidden'
+            >
+              프로필 수정
+            </OvalButton>
+          ) : (
+            <FollowButton
+              initFollowState={isFollow}
+              followUserId={userId}
+              isFull={true}
+            />
+          )}
+        </div>
+        <div className='relative flex-1 flex flex-col items-center mobile:items-start'>
+          <h3 className='mb-[43px] mobile:mb-[29px]'>{nickname}</h3>
+          <div className='mb-10'>
+            <p className='subtitle1 mb-[15px] mobile:mb-[25px] text-center mobile:text-start'>
+              {userField || '없음'}
+            </p>
+            <p className='subtitle2'>
+              {introduction}
+              Lorem ipsum, dolor sit amet consectetur adipisicing elit. Culpa
+              cumque, alias voluptatem quos repellat rem aliquam reprehenderit
+              quam ullam provident placeat veniam! Praesentium consequatur
+              doloribus nostrum. Illum asperiores similique doloribus!
+            </p>
+            {isMine && (
+              <OvalButton
+                buttonSize='s'
+                variant='primary'
+                onClick={changeMode}
+                className='w-full mobile:hidden mt-[30px]'
+              >
+                프로필 수정
+              </OvalButton>
+            )}
+          </div>
+          <div className='static tablet:absolute top-0 right-0 flex gap-10'>
+            <button
+              type='button'
+              className={
+                'flex gap-2.5 px-[28.5px] py-[12.5px] bg-gray-900 rounded-5px button-m'
+              }
+              onClick={() => clickFollowInfo('follower')}
+            >
+              <p>팔로워</p>
+              <p>{followerCount}</p>
+            </button>
+            <button
+              type='button'
+              className={
+                'flex gap-2.5 px-[28.5px] py-[12.5px] bg-gray-900 rounded-[5px] button-m'
+              }
+              onClick={() => clickFollowInfo('following')}
+            >
+              <p>팔로잉</p>
+              <p>{followingCount}</p>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DefaultUserInfo;

--- a/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
@@ -8,11 +8,11 @@ import modalStore from '@/stores/modalStore';
 import { UserType } from '@/types/user';
 
 interface DefaultUserInfoProps extends UserType {
-  changeMode: () => void;
+  toggleEditMode: () => void;
 }
 
 const DefaultUserInfo = ({
-  changeMode,
+  toggleEditMode,
   userId,
   profileImage,
   nickname,
@@ -49,7 +49,7 @@ const DefaultUserInfo = ({
             <OvalButton
               buttonSize='s'
               variant='primary'
-              onClick={changeMode}
+              onClick={toggleEditMode}
               className='w-full mobile:block hidden'
             >
               프로필 수정
@@ -75,7 +75,7 @@ const DefaultUserInfo = ({
               <OvalButton
                 buttonSize='s'
                 variant='primary'
-                onClick={changeMode}
+                onClick={toggleEditMode}
                 className='w-full mobile:hidden mt-[30px]'
               >
                 프로필 수정

--- a/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
@@ -39,7 +39,9 @@ const DefaultUserInfo = ({
           <Image
             src={profileImage || '/images/defaultProfileImage.png'}
             alt={profileImage ? 'user-profile-image' : 'default-profile'}
-            className={'rounded-full mb-[30px] mobile:mb-[40px]'}
+            className={
+              'rounded-full w-[141px] h-[141px] mb-[30px] mobile:mb-[40px]'
+            }
             width={141}
             height={141}
           />

--- a/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
@@ -68,7 +68,7 @@ const DefaultUserInfo = ({
           </h3>
           <div className='mb-10'>
             <p className='subtitle2 mobile:subtitle1 mb-[15px] mobile:mb-[25px] text-center mobile:text-start'>
-              {userField || '없음'}
+              {userField || '\u00A0'}
             </p>
             <p className='placeholder tablet:subtitle2'>{introduction}</p>
             {isMine && (

--- a/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/DefaultUserInfo.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
 import { useStore } from 'zustand';
 
-import DefaultProfile from '@/../public/images/defaultProfileImage.png';
 import FollowButton from '@/components/Button/FollowButton';
 import OvalButton from '@/components/Button/OvalButton';
 import FollowInfoModal from '@/components/Modal/FollowInfoModal';
@@ -38,7 +37,7 @@ const DefaultUserInfo = ({
       <div className='relative flex flex-col mobile:flex-row mobile:gap-[95px] gap-[30px] items-center mobile:items-start'>
         <div className='w-[141px]'>
           <Image
-            src={profileImage || DefaultProfile}
+            src={profileImage || '/images/defaultProfileImage.png'}
             alt={profileImage ? 'user-profile-image' : 'default-profile'}
             className={'rounded-full mb-[30px] mobile:mb-[40px]'}
             width={141}
@@ -67,13 +66,7 @@ const DefaultUserInfo = ({
             <p className='subtitle1 mb-[15px] mobile:mb-[25px] text-center mobile:text-start'>
               {userField || '없음'}
             </p>
-            <p className='subtitle2'>
-              {introduction}
-              Lorem ipsum, dolor sit amet consectetur adipisicing elit. Culpa
-              cumque, alias voluptatem quos repellat rem aliquam reprehenderit
-              quam ullam provident placeat veniam! Praesentium consequatur
-              doloribus nostrum. Illum asperiores similique doloribus!
-            </p>
+            <p className='subtitle2'>{introduction}</p>
             {isMine && (
               <OvalButton
                 buttonSize='s'

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -6,14 +6,13 @@ import { ChangeEvent, useMemo, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
+import { UpdateProfileInfoProps } from '@/apis/user/updateProfileInfo';
 import OvalButton from '@/components/Button/OvalButton';
 import Icon from '@/components/Icon/Icon';
 import BasicInput from '@/components/Input/BasicInput';
 import SortDropdown from '@/components/SortDropdown';
 import ARTWORK_FIELDS from '@/constants/artworkFields';
-import usePatchProfileInfo, {
-  UsePatchProfileInfoProps,
-} from '@/hooks/serverStateHooks/usePatchProfileInfo';
+import usePatchProfileInfo from '@/hooks/serverStateHooks/usePatchProfileInfo';
 import { UserStringProfileType, UserType } from '@/types/user';
 
 const USER_INFO_SCHEMA = z.object({
@@ -88,7 +87,7 @@ const EditUserInfo = ({
   const onSubmit = (data: UserInfoFormData) => {
     const newProfileData = {
       updateInfo: {} as UserStringProfileType,
-    } as UsePatchProfileInfoProps;
+    } as UpdateProfileInfoProps;
 
     if (data.nickname !== nickname)
       newProfileData.updateInfo.nickname = data.nickname;

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -6,11 +6,10 @@ import { ChangeEvent, useMemo, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import DefaultProfile from '@/../public/images/defaultProfileImage.png';
 import OvalButton from '@/components/Button/OvalButton';
-import FilterDropdown from '@/components/FilterDropdown';
 import Icon from '@/components/Icon/Icon';
 import BasicInput from '@/components/Input/BasicInput';
+import SortDropdown from '@/components/SortDropdown';
 import ARTWORK_FIELDS from '@/constants/artworkFields';
 import usePatchProfileInfo, {
   UsePatchProfileInfoProps,
@@ -80,11 +79,10 @@ const EditUserInfo = ({
   };
 
   const convertedProfileImage = useMemo(() => {
-    console.log(currentProfileImage);
     if (currentProfileImage instanceof File)
       return URL.createObjectURL(currentProfileImage);
     if (typeof currentProfileImage === 'string') return currentProfileImage;
-    return DefaultProfile;
+    return '/images/defaultProfileImage.png';
   }, [currentProfileImage]);
 
   const onSubmit = (data: UserInfoFormData) => {
@@ -158,7 +156,7 @@ const EditUserInfo = ({
             maxLength={MAX_NICKNAME_LENGTH}
           />
 
-          <FilterDropdown
+          <SortDropdown
             label='작품 카테고리'
             placeholder='카테고리 선택'
             options={ARTWORK_FIELDS.map((field) => field.name)}

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import Image from 'next/image';
+import { ChangeEvent, useMemo, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import DefaultProfile from '@/../public/images/defaultProfileImage.png';
+import OvalButton from '@/components/Button/OvalButton';
+import FilterDropdown from '@/components/FilterDropdown';
+import Icon from '@/components/Icon/Icon';
+import BasicInput from '@/components/Input/BasicInput';
+import ARTWORK_FIELDS from '@/constants/artworkFields';
+import usePatchProfileInfo, {
+  UsePatchProfileInfoProps,
+} from '@/hooks/serverStateHooks/usePatchProfileInfo';
+import { UserStringProfileType, UserType } from '@/types/user';
+
+const USER_INFO_SCHEMA = z.object({
+  nickname: z.string().min(1, '닉네임을 입력해주세요.'),
+  introduction: z.string().min(1, '자기 소개를 입력해주세요.'),
+  userField: z.string().optional(),
+  profileImage: z.union([z.string(), z.instanceof(File)]).optional(),
+});
+
+const MAX_NICKNAME_LENGTH = 10;
+const MAX_INTRODUCTION_LENGTH = 60;
+
+type UserInfoFormData = z.infer<typeof USER_INFO_SCHEMA>;
+
+interface EditUserInfoProps extends UserType {
+  changeMode: () => void;
+}
+
+const EditUserInfo = ({
+  changeMode,
+  profileImage,
+  nickname,
+  introduction,
+  userField,
+}: EditUserInfoProps) => {
+  const imageUploadRef = useRef<HTMLInputElement | null>(null);
+  const { updateUserProfile } = usePatchProfileInfo();
+
+  const {
+    trigger,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<UserInfoFormData>({
+    resolver: zodResolver(USER_INFO_SCHEMA),
+    mode: 'all',
+    defaultValues: {
+      nickname,
+      introduction,
+      userField,
+      profileImage,
+    },
+  });
+
+  const currentProfileImage = watch('profileImage');
+
+  const changeImage = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setValue('profileImage', file, { shouldValidate: true });
+    }
+  };
+
+  const changeNickname = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue('nickname', event.target.value);
+    trigger('nickname');
+  };
+
+  const changeIntroduction = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue('introduction', event.target.value);
+    trigger('introduction');
+  };
+
+  const convertedProfileImage = useMemo(() => {
+    console.log(currentProfileImage);
+    if (currentProfileImage instanceof File)
+      return URL.createObjectURL(currentProfileImage);
+    if (typeof currentProfileImage === 'string') return currentProfileImage;
+    return DefaultProfile;
+  }, [currentProfileImage]);
+
+  const onSubmit = (data: UserInfoFormData) => {
+    const newProfileData = {
+      updateInfo: {} as UserStringProfileType,
+    } as UsePatchProfileInfoProps;
+
+    if (data.nickname !== nickname)
+      newProfileData.updateInfo.nickname = data.nickname;
+    if (data.introduction !== introduction)
+      newProfileData.updateInfo.introduction = data.introduction;
+    if (data.userField !== userField) {
+      const selectedField = ARTWORK_FIELDS.find(
+        (field) => field.name === data.userField,
+      );
+      newProfileData.updateInfo.userField = selectedField?.value;
+    }
+
+    if (data.profileImage instanceof File) {
+      newProfileData.imageFile = data.profileImage;
+    }
+
+    updateUserProfile(newProfileData, {
+      onSuccess: () => {
+        alert('프로필이 성공적으로 업데이트되었습니다!');
+        changeMode();
+      },
+    });
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className='flex flex-col mobile:flex-row gap-[35px] mobile:gap-[70px] items-center mobile:items-start justify-center'
+    >
+      <button
+        type='button'
+        className='relative w-fit'
+        onClick={() => imageUploadRef.current?.click()}
+      >
+        <Image
+          src={convertedProfileImage}
+          alt='user-profile-image'
+          className='rounded-full'
+          width={141}
+          height={141}
+        />
+        <div className='absolute right-[3px] bottom-[-6px] w-fit p-4 bg-background-overlay/50 rounded-full backdrop-blur-md'>
+          <Icon name='EditPencil' className='text-transparent stroke-white' />
+        </div>
+        <input
+          type='file'
+          accept='image/*'
+          ref={imageUploadRef}
+          className='hidden'
+          onChange={changeImage}
+        />
+      </button>
+
+      <div className='flex-1 w-full'>
+        <div className='flex flex-col mobile:flex-row items-end mobile:gap-[70px] gap-[15px] pb-[15px]'>
+          <BasicInput
+            onChange={changeNickname}
+            value={watch('nickname') || ''}
+            label='닉네임'
+            placeholder='닉네임을 입력하세요'
+            className='w-full'
+            isInvalid={!!errors.nickname}
+            errorMessage={errors.nickname?.message}
+            showTextLength={true}
+            maxLength={MAX_NICKNAME_LENGTH}
+          />
+
+          <FilterDropdown
+            label='작품 카테고리'
+            placeholder='카테고리 선택'
+            options={ARTWORK_FIELDS.map((field) => field.name)}
+            selected={watch('userField') || 'OTHERS'}
+            onChange={(value) => setValue('userField', value)}
+            className='w-full'
+          />
+        </div>
+
+        <BasicInput
+          onChange={changeIntroduction}
+          value={watch('introduction') || ''}
+          label='한 줄 소개'
+          placeholder='한 줄 소개를 입력하세요'
+          className='w-full'
+          isInvalid={!!errors.introduction}
+          errorMessage={errors.introduction?.message}
+          showTextLength={true}
+          maxLength={MAX_INTRODUCTION_LENGTH}
+        />
+
+        <div className='flex flex-col-reverse mobile:flex-row gap-2.5 justify-end mt-9'>
+          <OvalButton
+            buttonSize='s'
+            variant='tertiary'
+            className='bg-transparent py-[20px] px-[34px] leading-none'
+            onClick={changeMode}
+          >
+            취소
+          </OvalButton>
+          <OvalButton
+            buttonSize='s'
+            variant='primary'
+            className='py-[20px] px-[34px] leading-none'
+            type='submit'
+            disabled={!isValid}
+          >
+            완료
+          </OvalButton>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default EditUserInfo;

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -29,11 +29,11 @@ const MAX_INTRODUCTION_LENGTH = 60;
 type UserInfoFormData = z.infer<typeof USER_INFO_SCHEMA>;
 
 interface EditUserInfoProps extends UserType {
-  changeMode: () => void;
+  toggleEditMode: () => void;
 }
 
 const EditUserInfo = ({
-  changeMode,
+  toggleEditMode,
   profileImage,
   nickname,
   introduction,
@@ -108,7 +108,7 @@ const EditUserInfo = ({
     updateUserProfile(newProfileData, {
       onSuccess: () => {
         alert('프로필이 성공적으로 업데이트되었습니다!');
-        changeMode();
+        toggleEditMode();
       },
     });
   };
@@ -185,7 +185,7 @@ const EditUserInfo = ({
             buttonSize='s'
             variant='tertiary'
             className='bg-transparent py-[20px] px-[34px] leading-none'
-            onClick={changeMode}
+            onClick={toggleEditMode}
           >
             취소
           </OvalButton>

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -18,7 +18,7 @@ import { UserStringProfileType, UserType } from '@/types/user';
 const USER_INFO_SCHEMA = z.object({
   nickname: z.string().min(1, '닉네임을 입력해주세요.'),
   introduction: z.string().min(1, '자기 소개를 입력해주세요.'),
-  userField: z.string().optional(),
+  field: z.string().optional(),
   profileImage: z.union([z.string(), z.instanceof(File)]).optional(),
 });
 
@@ -53,7 +53,7 @@ const EditUserInfo = ({
     defaultValues: {
       nickname,
       introduction,
-      userField,
+      field: userField,
       profileImage,
     },
   });
@@ -93,11 +93,11 @@ const EditUserInfo = ({
       newProfileData.updateInfo.nickname = data.nickname;
     if (data.introduction !== introduction)
       newProfileData.updateInfo.introduction = data.introduction;
-    if (data.userField !== userField) {
+    if (data.field !== userField) {
       const selectedField = ARTWORK_FIELDS.find(
-        (field) => field.name === data.userField,
+        (field) => field.name === data.field,
       );
-      newProfileData.updateInfo.userField = selectedField?.value;
+      newProfileData.updateInfo.field = selectedField?.value;
     }
 
     if (data.profileImage instanceof File) {
@@ -160,8 +160,8 @@ const EditUserInfo = ({
               label='작품 카테고리'
               placeholder='카테고리 선택'
               options={ARTWORK_FIELDS.map((field) => field.name)}
-              selected={watch('userField') || 'OTHERS'}
-              onChange={(value) => setValue('userField', value)}
+              selected={watch('field') || 'OTHERS'}
+              onChange={(value) => setValue('field', value)}
               className='w-full'
             />
           </span>

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -126,7 +126,7 @@ const EditUserInfo = ({
         <Image
           src={convertedProfileImage}
           alt='user-profile-image'
-          className='rounded-full'
+          className={'rounded-full w-[141px] h-[141px]'}
           width={141}
           height={141}
         />

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -131,7 +131,7 @@ const EditUserInfo = ({
           height={141}
         />
         <div className='absolute right-[3px] bottom-[-6px] w-fit p-4 bg-background-overlay/50 rounded-full backdrop-blur-md'>
-          <Icon name='EditPencil' className='text-transparent stroke-white' />
+          <Icon name='EditPencil' className='text-white' />
         </div>
         <input
           type='file'

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -126,7 +126,7 @@ const EditUserInfo = ({
         <Image
           src={convertedProfileImage}
           alt='user-profile-image'
-          className={'rounded-full w-[141px] h-[141px]'}
+          className='rounded-full w-[141px] h-[141px]'
           width={141}
           height={141}
         />

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -143,7 +143,7 @@ const EditUserInfo = ({
       </button>
 
       <div className='flex-1 w-full'>
-        <div className='flex flex-col mobile:flex-row items-end mobile:gap-[70px] gap-[15px] pb-[15px]'>
+        <div className='flex flex-col mobile:flex-row mobile:items-center items-end mobile:gap-[70px] gap-[15px] pb-[15px]'>
           <BasicInput
             onChange={changeNickname}
             value={watch('nickname') || ''}
@@ -156,14 +156,16 @@ const EditUserInfo = ({
             maxLength={MAX_NICKNAME_LENGTH}
           />
 
-          <SortDropdown
-            label='작품 카테고리'
-            placeholder='카테고리 선택'
-            options={ARTWORK_FIELDS.map((field) => field.name)}
-            selected={watch('userField') || 'OTHERS'}
-            onChange={(value) => setValue('userField', value)}
-            className='w-full'
-          />
+          <span className='w-full mb-[38px]'>
+            <SortDropdown
+              label='작품 카테고리'
+              placeholder='카테고리 선택'
+              options={ARTWORK_FIELDS.map((field) => field.name)}
+              selected={watch('userField') || 'OTHERS'}
+              onChange={(value) => setValue('userField', value)}
+              className='w-full'
+            />
+          </span>
         </div>
 
         <BasicInput

--- a/src/components/ProfilePage/UserInfoSection/index.tsx
+++ b/src/components/ProfilePage/UserInfoSection/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState } from 'react';
+
+import { UserType } from '@/types/user';
+
+import DefaultUserInfo from './DefaultUserInfo';
+import EditUserInfo from './EditUserInfo';
+
+const UserInfoSection = ({ userInfo }: { userInfo: UserType }) => {
+  const [isEdit, setIsEdit] = useState(false);
+
+  const changeMode = () => setIsEdit((state) => !state);
+
+  const userNameText = userInfo.isMine ? '나' : userInfo.nickname;
+
+  return (
+    <div>
+      <h2 className='mb-[70px] mobile:mb-[50px]'>{userNameText}의 모멘티아</h2>
+      {isEdit ? (
+        <EditUserInfo changeMode={changeMode} {...userInfo} />
+      ) : (
+        <DefaultUserInfo changeMode={changeMode} {...userInfo} />
+      )}
+    </div>
+  );
+};
+
+export default UserInfoSection;

--- a/src/components/ProfilePage/UserInfoSection/index.tsx
+++ b/src/components/ProfilePage/UserInfoSection/index.tsx
@@ -8,16 +8,16 @@ import DefaultUserInfo from './DefaultUserInfo';
 import EditUserInfo from './EditUserInfo';
 
 const UserInfoSection = ({ userInfo }: { userInfo: UserType }) => {
-  const [isEdit, setIsEdit] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
-  const changeMode = () => setIsEdit((state) => !state);
+  const changeMode = () => setIsEditing((state) => !state);
 
   const userNameText = userInfo.isMine ? '나' : userInfo.nickname;
 
   return (
     <div>
       <h2 className='mb-[70px] mobile:mb-[50px]'>{userNameText}의 모멘티아</h2>
-      {isEdit ? (
+      {isEditing ? (
         <EditUserInfo changeMode={changeMode} {...userInfo} />
       ) : (
         <DefaultUserInfo changeMode={changeMode} {...userInfo} />

--- a/src/components/ProfilePage/UserInfoSection/index.tsx
+++ b/src/components/ProfilePage/UserInfoSection/index.tsx
@@ -10,7 +10,7 @@ import EditUserInfo from './EditUserInfo';
 const UserInfoSection = ({ userInfo }: { userInfo: UserType }) => {
   const [isEditing, setIsEditing] = useState(false);
 
-  const changeMode = () => setIsEditing((state) => !state);
+  const toggleEditMode = () => setIsEditing((state) => !state);
 
   const userNameText = userInfo.isMine ? '나' : userInfo.nickname;
 
@@ -18,9 +18,9 @@ const UserInfoSection = ({ userInfo }: { userInfo: UserType }) => {
     <div>
       <h2 className='mb-[70px] mobile:mb-[50px]'>{userNameText}의 모멘티아</h2>
       {isEditing ? (
-        <EditUserInfo changeMode={changeMode} {...userInfo} />
+        <EditUserInfo toggleEditMode={toggleEditMode} {...userInfo} />
       ) : (
-        <DefaultUserInfo changeMode={changeMode} {...userInfo} />
+        <DefaultUserInfo toggleEditMode={toggleEditMode} {...userInfo} />
       )}
     </div>
   );

--- a/src/components/SortDropdown/index.tsx
+++ b/src/components/SortDropdown/index.tsx
@@ -51,6 +51,7 @@ const SortDropdown = ({
       )}
 
       <button
+        type='button'
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
         aria-label={`Currently selected filter: ${selected || placeholder}`}
         aria-expanded={isDropdownOpen}

--- a/src/constants/API.ts
+++ b/src/constants/API.ts
@@ -9,6 +9,7 @@ const USER = {
   userProfile: '/user',
   artworkList: '/artwork/user/posts',
   likedArtworkList: '/artwork/like/posts',
+  followerList: (userId: number) => `/user/${userId}/followerList`,
 };
 
 const MONTHLY = {

--- a/src/constants/API.ts
+++ b/src/constants/API.ts
@@ -10,6 +10,7 @@ const USER = {
   artworkList: '/artwork/user/posts',
   likedArtworkList: '/artwork/like/posts',
   followerList: (userId: number) => `/user/${userId}/followerList`,
+  followingList: (userId: number) => `/user/${userId}/followingList`,
 };
 
 const MONTHLY = {

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -83,3 +83,10 @@ export const COLLECTION_PATCH_ERROR_MESSAGE: MessageConstantType = {
 export const COLLECTION_ARTWORKS_ERROR_MESSAGE: MessageConstantType = {
   COLLECTION_NOT_FOUND: '요청한 컬렉션 id에 해당하는 컬렉션이 없습니다.',
 };
+
+export const EDIT_USER_PROFILE_ERROR_MESSAGE: MessageConstantType = {
+  INVALID_FIELD: '작업 분야에 해당하는 형식이 아닙니다.',
+  INVALID_NICKNAME: '사용할 수 없는 닉네임 입니다.',
+  INVALID_INTRODUCTION: '잘못된 형태의 자기소개 입니다.',
+  DUPLICATE_NICKNAME: '이미 사용중인 닉네임 입니다.',
+};

--- a/src/hooks/serverStateHooks/useGetFollowerList.ts
+++ b/src/hooks/serverStateHooks/useGetFollowerList.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+
+import getFollowerList from '@/apis/follow/getFollowerList';
+import { USER } from '@/constants/API';
+import { FollowUser } from '@/types/user';
+
+const useGetFollowerList = () => {
+  const searchParams = useSearchParams();
+  const userIdParam = searchParams.get('userId');
+  const userId = userIdParam ? Number(userIdParam) : null;
+
+  const { data, isLoading } = useQuery({
+    queryKey: [USER.followerList(userId as number)],
+    queryFn: () => getFollowerList(userId as number),
+  });
+
+  return {
+    followerList: data !== undefined ? data.users : ([] as FollowUser[]),
+    isLoading,
+  };
+};
+
+export default useGetFollowerList;

--- a/src/hooks/serverStateHooks/useGetFollowerList.ts
+++ b/src/hooks/serverStateHooks/useGetFollowerList.ts
@@ -3,7 +3,6 @@ import { useSearchParams } from 'next/navigation';
 
 import getFollowerList from '@/apis/follow/getFollowerList';
 import { USER } from '@/constants/API';
-import { FollowUser } from '@/types/user';
 
 const useGetFollowerList = () => {
   const searchParams = useSearchParams();
@@ -16,7 +15,7 @@ const useGetFollowerList = () => {
   });
 
   return {
-    followerList: data !== undefined ? data.users : ([] as FollowUser[]),
+    followerList: data?.users ?? [],
     isLoading,
   };
 };

--- a/src/hooks/serverStateHooks/useGetFollowingList.tsx
+++ b/src/hooks/serverStateHooks/useGetFollowingList.tsx
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+
+import getFollowingList from '@/apis/follow/getFollowingList';
+import { USER } from '@/constants/API';
+import { FollowUser } from '@/types/user';
+
+const useGetFollowingList = () => {
+  const searchParams = useSearchParams();
+  const userIdParam = searchParams.get('userId');
+  const userId = userIdParam ? Number(userIdParam) : null;
+
+  const { data, isLoading } = useQuery({
+    queryKey: [USER.followingList(userId as number)],
+    queryFn: () => getFollowingList(userId as number),
+    enabled: !!userId,
+  });
+
+  return {
+    followingList: data !== undefined ? data.users : ([] as FollowUser[]),
+    isLoading,
+  };
+};
+
+export default useGetFollowingList;

--- a/src/hooks/serverStateHooks/useGetFollowingList.tsx
+++ b/src/hooks/serverStateHooks/useGetFollowingList.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from 'next/navigation';
 
 import getFollowingList from '@/apis/follow/getFollowingList';
 import { USER } from '@/constants/API';
-import { FollowUser } from '@/types/user';
 
 const useGetFollowingList = () => {
   const searchParams = useSearchParams();
@@ -17,7 +16,7 @@ const useGetFollowingList = () => {
   });
 
   return {
-    followingList: data !== undefined ? data.users : ([] as FollowUser[]),
+    followingList: data?.users ?? [],
     isLoading,
   };
 };

--- a/src/hooks/serverStateHooks/usePatchProfileInfo.ts
+++ b/src/hooks/serverStateHooks/usePatchProfileInfo.ts
@@ -1,0 +1,71 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  postPresignedUrl,
+  putNotifyImageUploadComplete,
+  putUploadImageToS3,
+} from '@/apis/image/postImage';
+import patchProfileInfo from '@/apis/user/patchProfileInfo';
+import { USER } from '@/constants/API';
+import { UpdateProfileType, UserStringProfileType } from '@/types/user';
+import TokenHandler from '@/utils/tokenHandler';
+
+export interface UsePatchProfileInfoProps {
+  imageFile?: File;
+  updateInfo: UserStringProfileType;
+}
+
+const usePatchProfileInfo = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate: updateUserProfile, isPending } = useMutation({
+    mutationFn: async ({ imageFile, updateInfo }: UsePatchProfileInfoProps) => {
+      try {
+        const newProfile = { ...updateInfo } as UpdateProfileType;
+        let imageId: number = 0;
+
+        if (imageFile) {
+          const presignedData = await postPresignedUrl({
+            fileSize: imageFile.size,
+            fileType: imageFile.type,
+          });
+
+          if (!presignedData) throw new Error('Presigned URL 요청 실패');
+
+          const { presignedUrl, imageId: newImageId } = presignedData;
+          imageId = newImageId;
+
+          const uploadSuccess = await putUploadImageToS3({
+            file: imageFile,
+            uploadUrl: presignedUrl,
+          });
+
+          if (!uploadSuccess) throw new Error('이미지 업로드 실패');
+
+          const result = await putNotifyImageUploadComplete(imageId);
+
+          if (result) newProfile.profileImage = imageId;
+        }
+
+        return await patchProfileInfo(newProfile);
+      } catch (error) {
+        console.error('프로필 업데이트 중 오류 발생:', error);
+        throw error;
+      }
+    },
+    onError: (error) => {
+      alert(`프로필 업데이트 실패: ${error.message}`);
+    },
+    onSuccess: () => {
+      const userId = TokenHandler.getUserIdFromToken();
+
+      queryClient.invalidateQueries({
+        queryKey: [USER.userProfile, userId],
+      });
+    },
+  });
+
+  return { updateUserProfile, isPending };
+};
+
+export default usePatchProfileInfo;

--- a/src/hooks/serverStateHooks/usePatchProfileInfo.ts
+++ b/src/hooks/serverStateHooks/usePatchProfileInfo.ts
@@ -1,58 +1,14 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import {
-  postPresignedUrl,
-  putNotifyImageUploadComplete,
-  putUploadImageToS3,
-} from '@/apis/image/postImage';
-import patchProfileInfo from '@/apis/user/patchProfileInfo';
+import updateProfileInfo from '@/apis/user/updateProfileInfo';
 import { USER } from '@/constants/API';
-import { UpdateProfileType, UserStringProfileType } from '@/types/user';
 import TokenHandler from '@/utils/tokenHandler';
-
-export interface UsePatchProfileInfoProps {
-  imageFile?: File;
-  updateInfo: UserStringProfileType;
-}
 
 const usePatchProfileInfo = () => {
   const queryClient = useQueryClient();
 
   const { mutate: updateUserProfile, isPending } = useMutation({
-    mutationFn: async ({ imageFile, updateInfo }: UsePatchProfileInfoProps) => {
-      try {
-        const newProfile = { ...updateInfo } as UpdateProfileType;
-        let imageId: number = 0;
-
-        if (imageFile) {
-          const presignedData = await postPresignedUrl({
-            fileSize: imageFile.size,
-            fileType: imageFile.type,
-          });
-
-          if (!presignedData) throw new Error('Presigned URL 요청 실패');
-
-          const { presignedUrl, imageId: newImageId } = presignedData;
-          imageId = newImageId;
-
-          const uploadSuccess = await putUploadImageToS3({
-            file: imageFile,
-            uploadUrl: presignedUrl,
-          });
-
-          if (!uploadSuccess) throw new Error('이미지 업로드 실패');
-
-          const result = await putNotifyImageUploadComplete(imageId);
-
-          if (result) newProfile.profileImage = imageId;
-        }
-
-        return await patchProfileInfo(newProfile);
-      } catch (error) {
-        console.error('프로필 업데이트 중 오류 발생:', error);
-        throw error;
-      }
-    },
+    mutationFn: updateProfileInfo,
     onError: (error) => {
       alert(`프로필 업데이트 실패: ${error.message}`);
     },

--- a/src/styles/shadow.css
+++ b/src/styles/shadow.css
@@ -1,0 +1,3 @@
+.shadow {
+  box-shadow: 0px 3px 8px 0px rgba(0, 0, 0, 0.06);
+}

--- a/src/types/artist.ts
+++ b/src/types/artist.ts
@@ -3,7 +3,7 @@ import { UserType } from './user';
 export interface ArtistInfoType
   extends Omit<
     UserType,
-    'isMine' | 'email' | 'followingCount' | 'followerCount' | 'field'
+    'isMine' | 'email' | 'followingCount' | 'followerCount' | 'userField'
   > {
   userField: string;
   artworkImage: string;

--- a/src/types/buttons/OvalButtonProps.ts
+++ b/src/types/buttons/OvalButtonProps.ts
@@ -1,7 +1,7 @@
 import { BaseButtonProps } from './BaseButtonProps';
 
 export interface OvalButtonProps
-  extends Omit<BaseButtonProps, 'loading' | 'icon' | 'iconPosition' | 'type'> {
+  extends Omit<BaseButtonProps, 'loading' | 'icon' | 'iconPosition'> {
   buttonSize: 's' | 'm';
   className?: string;
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -30,3 +30,16 @@ export interface UserArtworkResponse extends ArtworkListResponse {
   data: UserArtworkInfoType[];
   isMine: boolean;
 }
+
+export interface FollowUser
+  extends Pick<
+    UserType,
+    'userId' | 'profileImage' | 'nickname' | 'introduction'
+  > {}
+
+export interface UserStringProfileType
+  extends Partial<Pick<UserType, 'nickname' | 'userField' | 'introduction'>> {}
+
+export interface UpdateProfileType extends Partial<UserStringProfileType> {
+  profileImage?: number;
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -31,7 +31,7 @@ export interface UserArtworkResponse extends ArtworkListResponse {
   isMine: boolean;
 }
 
-export interface FollowUser
+export interface FollowUserType
   extends Pick<
     UserType,
     'userId' | 'profileImage' | 'nickname' | 'introduction'

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -34,7 +34,7 @@ export interface UserArtworkResponse extends ArtworkListResponse {
 export interface FollowUserType
   extends Pick<
     UserType,
-    'userId' | 'profileImage' | 'nickname' | 'introduction'
+    'userId' | 'profileImage' | 'nickname' | 'introduction' | 'isFollow'
   > {}
 
 export interface UserStringProfileType

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -38,7 +38,9 @@ export interface FollowUserType
   > {}
 
 export interface UserStringProfileType
-  extends Partial<Pick<UserType, 'nickname' | 'userField' | 'introduction'>> {}
+  extends Partial<Pick<UserType, 'nickname' | 'introduction'>> {
+  field?: string;
+}
 
 export interface UpdateProfileType extends Partial<UserStringProfileType> {
   profileImage?: number;


### PR DESCRIPTION
## 📝 작업 내용
- [x] 프로필 페이지 상단 작가 정보 영역 구현
- [x] 작가 정보 컴포넌트 영역 구현
- [x] 작가 정보 수정 컴포넌트 영역 구현
  - [x] 수정 form 제출 로직 추가
  - [x] 작가 정보 수정 api, 커스텀 훅 추가 
- 팔로워/팔로잉 모달 구현
  - 팔로워/팔로잉 리스트 조회 api 및 커스텀 훅 추가

## 📸 스크린샷
![Feb-12-2025 09-39-39](https://github.com/user-attachments/assets/4ac3ecb2-5922-44bf-9e70-a598eb056fb0)
![Feb-12-2025 09-22-30](https://github.com/user-attachments/assets/9f65991c-0cb9-4bb5-9af3-2e2891390f74)



## 💬 리뷰 요구사항 
