### PR TITLE
[FIX] fix, feat: 컬렉션 작품 개수 조회 및 UI 오류 수정, 컬렉션 삭제 시 Redirection 기능 추가

### DIFF
--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { useStore } from 'zustand';
 
@@ -44,6 +44,7 @@ const Collection = () => {
   });
 
   const artworksLength = artworks.length;
+  const router = useRouter();
 
   const openShareModal = () => {
     openModal({
@@ -75,6 +76,7 @@ const Collection = () => {
           queryKey: [COLLECTION.collectionList],
         });
         closeModal();
+        router.back();
       },
     });
   };

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -43,7 +43,7 @@ const Collection = () => {
     collectionId,
   });
 
-  const artworksLength = artworks.length;
+  const artworksLength = pageInfo.totalDataCnt;
   const router = useRouter();
 
   const openShareModal = () => {

--- a/src/components/CollectionPage/RenameCollectionModal.tsx
+++ b/src/components/CollectionPage/RenameCollectionModal.tsx
@@ -45,7 +45,7 @@ const RenameCollectionModal = ({
       {
         onSuccess: () => {
           queryClient.invalidateQueries({
-            queryKey: [COLLECTION.collectionList],
+            queryKey: [COLLECTION.collection],
           });
           closeModal();
         },

--- a/src/components/Modal/ShareModal.tsx
+++ b/src/components/Modal/ShareModal.tsx
@@ -33,7 +33,7 @@ const ShareModal = ({ title, nickname, artworksLength }: ShareModalProps) => {
     <div className='flex flex-col tablet:px-[56px] px-[18px] py-[50px]'>
       <div className='flex justify-between items-center'>
         {nickname && <h2 className='text-gray-100'>작품 공유</h2>}
-        {artworksLength && <h2 className='text-gray-100'>컬렉션 공유</h2>}
+        {title && <h2 className='text-gray-100'>컬렉션 공유</h2>}
         <Icon
           name='Close'
           size='l'
@@ -45,7 +45,7 @@ const ShareModal = ({ title, nickname, artworksLength }: ShareModalProps) => {
       <div className='flex gap-5 items-center mt-5'>
         <p className='subtitle2 text-gray-200'>{title}</p>
         {nickname && <p className='body1 text-gray-300'>{nickname}</p>}
-        {artworksLength && (
+        {title && (
           <p className='body1 text-gray-300'>{artworksLength}개의 작품</p>
         )}
       </div>


### PR DESCRIPTION
## 📝 작업 내용
1. 컬렉션 이름 수정 시, 새로고침 해야 화면에 반영되는 문제 해결
2. 컬렉션 작품 개수 조회 관련 로직 수정
3. 컬렉션 내 작품이 없을 때, 공유 모달에서 0이 표시되는 문제 해결
4. 컬렉션 삭제 시, 바로 페이지 이동 (Redirect) 기능 추가


## 📸 스크린샷 (선택)
<img width="628" alt="image" src="https://github.com/user-attachments/assets/f623aa37-a0f8-40e1-8d2f-69a9ec69d19f" />