### PR TITLE
[FIX] fix: 컬렉션 생성 후 즉시 반영되도록 수정 및 중복 이름 alert 추가

### DIFF
--- a/src/apis/collection/postCollection.ts
+++ b/src/apis/collection/postCollection.ts
@@ -1,4 +1,11 @@
+import { isAxiosError } from 'axios';
+
 import { COLLECTION } from '@/constants/API';
+import {
+  COLLECTION_POST_ERROR_MESSAGE,
+  COMMON_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { ErrorResponseType } from '@/types/errorResponse';
 
 import { authorizedClient } from '..';
 
@@ -8,12 +15,30 @@ export interface PostCollectionProps {
 }
 
 const postCollection = async ({ name, isPrivate }: PostCollectionProps) => {
-  const response = await authorizedClient.post(COLLECTION.collection, {
-    name,
-    status: isPrivate ? 'PRIVATE' : 'PUBLIC',
-  });
+  try {
+    const response = await authorizedClient.post(COLLECTION.collection, {
+      name,
+      status: isPrivate ? 'PRIVATE' : 'PUBLIC',
+    });
 
-  return response.status === 201;
+    return response.status === 201;
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        console.error(COLLECTION_POST_ERROR_MESSAGE[code]);
+        throw new Error(COLLECTION_POST_ERROR_MESSAGE[code]);
+      } else {
+        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+        throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      alert('이미 존재하는 컬렉션 이름입니다.');
+      // console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      // throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
+  }
 };
 
 export default postCollection;

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { useStore } from 'zustand';
 
@@ -44,6 +44,7 @@ const Collection = () => {
   });
 
   const artworksLength = artworks.length;
+  const router = useRouter();
 
   const openShareModal = () => {
     openModal({
@@ -75,6 +76,7 @@ const Collection = () => {
           queryKey: [COLLECTION.collectionList],
         });
         closeModal();
+        router.back();
       },
     });
   };

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -43,7 +43,7 @@ const Collection = () => {
     collectionId,
   });
 
-  const artworksLength = artworks.length;
+  const artworksLength = pageInfo.totalDataCnt;
   const router = useRouter();
 
   const openShareModal = () => {

--- a/src/components/CollectionPage/RenameCollectionModal.tsx
+++ b/src/components/CollectionPage/RenameCollectionModal.tsx
@@ -45,7 +45,7 @@ const RenameCollectionModal = ({
       {
         onSuccess: () => {
           queryClient.invalidateQueries({
-            queryKey: [COLLECTION.collectionList],
+            queryKey: [COLLECTION.collection],
           });
           closeModal();
         },

--- a/src/components/Modal/ShareModal.tsx
+++ b/src/components/Modal/ShareModal.tsx
@@ -33,7 +33,7 @@ const ShareModal = ({ title, nickname, artworksLength }: ShareModalProps) => {
     <div className='flex flex-col tablet:px-[56px] px-[18px] py-[50px]'>
       <div className='flex justify-between items-center'>
         {nickname && <h2 className='text-gray-100'>작품 공유</h2>}
-        {artworksLength && <h2 className='text-gray-100'>컬렉션 공유</h2>}
+        {title && <h2 className='text-gray-100'>컬렉션 공유</h2>}
         <Icon
           name='Close'
           size='l'
@@ -45,7 +45,7 @@ const ShareModal = ({ title, nickname, artworksLength }: ShareModalProps) => {
       <div className='flex gap-5 items-center mt-5'>
         <p className='subtitle2 text-gray-200'>{title}</p>
         {nickname && <p className='body1 text-gray-300'>{nickname}</p>}
-        {artworksLength && (
+        {title && (
           <p className='body1 text-gray-300'>{artworksLength}개의 작품</p>
         )}
       </div>

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -68,6 +68,10 @@ export const PROFILE_COLLECTION_GET_ERROR_MESSAGE: MessageConstantType = {
   NO_PERMISSION: 'userId를 찾을 수 없고, 로그인하지 않은 상태입니다.',
 };
 
+export const COLLECTION_POST_ERROR_MESSAGE: MessageConstantType = {
+  INVALID_COLLECTION_NAME: 'name이 비어 있거나 글자 수 제한이 위반되었습니다.',
+};
+
 export const COLLECTION_DELETE_ERROR_MESSAGE: MessageConstantType = {
   NO_PERMISSION: '본인의 컬렉션이 아닙니다.',
   COLLECTION_NOT_FOUND: '컬렉션 리소스를 찾을 수 없습니다.',

--- a/src/hooks/serverStateHooks/usePostCollection.tsx
+++ b/src/hooks/serverStateHooks/usePostCollection.tsx
@@ -13,7 +13,7 @@ import modalStore from '@/stores/modalStore';
 const usePostCollection = () => {
   const { openModal, closeModal } = useStore(modalStore);
   const queryClient = useQueryClient();
-  const isProfile = usePathname().includes('collection');
+  const isProfile = usePathname().includes('profile');
 
   const { mutate } = useMutation({
     mutationFn: ({ name, isPrivate }: PostCollectionProps) =>


### PR DESCRIPTION
## 📝 작업 내용
1. 컬렉션 Tab에서 컬렉션 생성 후, 새로고침해야 화면에 반영되는 문제 해결
2. 컬렉션 생성 시, 중복 이름을 입력하면 alert 표시하도록 수정


## 📸 스크린샷 (선택)
<img width="900" alt="image" src="https://github.com/user-attachments/assets/80f0221a-ae14-476f-ad1f-e765650255ea" />


## 💬 전달사항
<img width="900" alt="image" src="https://github.com/user-attachments/assets/f06bbd05-e20b-4bc8-8bd5-835d2f732141" />

아직 Back-end 측에서 '컬렉션 생성 (`POST`)' API에 컬렉션 이름 중복 Error Code를 전달하지 않은 상태라 컬렉션 이름이 중복될 경우의 처리를 `NETWORK_ERROR` 대신으로 넣어, 처리했습니다. 네트워크 에러는 임시로 우선 주석 처리하였으니 참고 바랍니다!