### PR TITLE
[FIX] feat: URL에 선택한 작품 카테고리 반영 및 새로고침 시 '내가 팔로우한 작가' 섹션 토글 상태가 유지되는 기능 추가

### DIFF
--- a/src/app/artwork/list/page.tsx
+++ b/src/app/artwork/list/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 
 import ArtworkFilter from '@/components/ArtworkListPage/ArtworkFilter';
@@ -10,9 +11,12 @@ import { ARTWORK_SORT_OPTIONS, ITEMS_PER_PAGE } from '@/constants/pagination';
 import useGetArtworkList from '@/hooks/serverStateHooks/useGetArtworkList';
 
 const ArtworkList = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selectedArtworkField = searchParams.get('category') || 'ALL';
+
   const [searchKeyword, setSearchKeyword] = useState('');
   const [submittedKeyword, setSubmittedKeyword] = useState('');
-  const [selectedArtworkField, setSelectedArtworkField] = useState('ALL');
   const [selectedOption, setSelectedOption] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -51,8 +55,9 @@ const ArtworkList = () => {
           setSubmittedKeyword={setSubmittedKeyword}
         />
         <ArtworkFilter
+          router={router}
+          searchParams={searchParams}
           selectedArtworkField={selectedArtworkField}
-          setSelectedArtworkField={setSelectedArtworkField}
           selectedOption={selectedOption}
           setSelectedOption={setSelectedOption}
           setCurrentPage={setCurrentPage}

--- a/src/components/ArtworkListPage/ArtworkFilter.tsx
+++ b/src/components/ArtworkListPage/ArtworkFilter.tsx
@@ -1,3 +1,5 @@
+import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+
 import { SORT_OPTIONS } from '@/constants/sortOptions';
 import { ArtworkField } from '@/types';
 
@@ -7,8 +9,9 @@ import DefaultCarousel from '../Carousel/DefaultCarousel';
 import SortDropdown from '../SortDropdown';
 
 interface ArtworkFilterProps {
+  router: AppRouterInstance;
+  searchParams: URLSearchParams;
   selectedArtworkField: string;
-  setSelectedArtworkField: (value: string | ((prev: string) => string)) => void;
   selectedOption: string;
   setSelectedOption: (value: string | ((prev: string) => string)) => void;
   setCurrentPage: (value: number | ((prev: number) => number)) => void;
@@ -20,8 +23,9 @@ const ARTWORK_FIELDS_WITH_ALL_OPTION = [
 ];
 
 const ArtworkFilter = ({
+  router,
+  searchParams,
   selectedArtworkField,
-  setSelectedArtworkField,
   selectedOption,
   setSelectedOption,
   setCurrentPage,
@@ -32,7 +36,9 @@ const ArtworkFilter = ({
     )?.name || '전체';
 
   const handleArtworkFieldClick = (artworkField: string) => {
-    setSelectedArtworkField(artworkField);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('category', artworkField);
+    router.replace(`?${params.toString()}`, { scroll: false });
     setCurrentPage(1);
   };
 

--- a/src/components/ArtworkListPage/FollowedArtistsSection.tsx
+++ b/src/components/ArtworkListPage/FollowedArtistsSection.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import DefaultCarousel from '@/components/Carousel/DefaultCarousel';
 import ROUTE from '@/constants/routes';
@@ -31,11 +31,26 @@ const FollowedArtistsSection = () => {
     router.push(ROUTE.profile(userId));
   };
 
+  useEffect(() => {
+    const savedState = localStorage.getItem('showFollowedArtistsCards');
+    if (savedState !== null) {
+      setShowFollowedArtistsCards(savedState === 'true');
+    }
+  }, []);
+
+  const toggleShowFollowedArtistsCards = () => {
+    setShowFollowedArtistsCards((prev) => {
+      const newState = !prev;
+      localStorage.setItem('showFollowedArtistsCards', String(newState));
+      return newState;
+    });
+  };
+
   return (
     <>
       <button
         className='flex items-center pb-[56px] w-[202px] justify-between'
-        onClick={() => setShowFollowedArtistsCards((prev) => !prev)}
+        onClick={toggleShowFollowedArtistsCards}
       >
         <h3 className='text-white'>내가 팔로우한 작가</h3>
         <Icon


### PR DESCRIPTION
## 📝 작업 내용
1. 작품 목록 페이지에서 선택한 작품 카테고리가 URL에 반영되고, URL을 공유해도 같은 필터가 유지되는 기능 추가
⇒ **새로고침 할 때마다 "전체" 카테고리가 보이는 불편함을 해소하고, 타 유저에게 필터 처리된 작품들을 공유할 수 있도록 수정**

2. 새로고침 이후에도 '내가 팔로우한 작가' 섹션 토글 상태가 유지되도록 수정
⇒ **새로고침하면 토글 상태가 초기화되는 불편함을 해결하여 UX 향상**


## 📸 스크린샷 (선택)
### (1) 선택한 작품 카테고리를 URL에 반영
<img width="1699" alt="image" src="https://github.com/user-attachments/assets/723959c6-22d7-4b2c-b822-1b3ec92a7ea3" />

### (2) '내가 팔로우한 작가' 섹션 토글 상태 유지
> #### 수정 전: 새로고침하면 '내가 팔로우한 작가' 토글 상태가 풀림
![새로고침하면 내가 팔로우한 작가 토글 상태가 풀림](https://github.com/user-attachments/assets/5433b5e4-9b59-42a9-9308-733d1f3fafb3)

> #### 수정 후: 새로고침해도 '내가 팔로우한 작가' 토글 상태가 유지됨
![새로고침해도 내가 팔로우한 작가 토글 상태가 유지됨](https://github.com/user-attachments/assets/7fbf53c9-cc1d-43b1-9eda-458db71b4810)