### PR TITLE
[TASK-110] feat: 성공/실패에 따른 ToastPopup 메시지 추가

### DIFF
--- a/.github/workflows/auto_labeling.yml
+++ b/.github/workflows/auto_labeling.yml
@@ -19,14 +19,17 @@ jobs:
         with:
           script: |
             const commitKeywords = {
-              feat: 'feature',
-              fix: 'bug',
+              feat: 'feat',
+              fix: 'fix',
               chore: 'chore',
-              docs: 'documentation',
+              docs: 'docs',
               style: 'style',
               refactor: 'refactor',
+              rename: 'rename',
+              remove: 'remove',
+              move: 'move',
               test: 'test',
-              perf: 'performance',
+              setting: 'setting',
             };
       
             // context와 github는 기본적으로 제공됨

--- a/src/apis/artwork/deleteArtwork.ts
+++ b/src/apis/artwork/deleteArtwork.ts
@@ -15,24 +15,19 @@ const deleteArtwork = async (postId: number) => {
       ARTWORK.patchArtwork(postId),
     );
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('작품 삭제 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('작품 삭제에 실패하였습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(ARTWORK_ERROR_MESSAGE[code]);
         throw new Error(ARTWORK_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/artwork/deleteArtworkComments.ts
+++ b/src/apis/artwork/deleteArtworkComments.ts
@@ -15,24 +15,19 @@ const deleteArtworkComments = async (postId: number) => {
       ARTWORK.artworkComment(postId),
     );
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('좋아요 취소 요청 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('댓글 삭제에 실패하였습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(COMMENT_ERROR_MESSAGE[code]);
         throw new Error(COMMENT_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/artwork/deleteArtworkComments.ts
+++ b/src/apis/artwork/deleteArtworkComments.ts
@@ -17,7 +17,7 @@ const deleteArtworkComments = async (postId: number) => {
 
     if (response.status === 204) return true;
 
-    throw new Error('댓글 삭제에 실패하였습니다.');
+    throw new Error('댓글이 삭제되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;

--- a/src/apis/artwork/deleteArtworkLike.ts
+++ b/src/apis/artwork/deleteArtworkLike.ts
@@ -13,24 +13,19 @@ const deleteArtworkLike = async (postId: number) => {
   try {
     const response = await authorizedClient.delete(ARTWORK.artworkLike(postId));
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('좋아요 취소 요청 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('좋아요 취소가 반영되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(LIKE_ERROR_MESSAGE[code]);
         throw new Error(LIKE_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/artwork/deleteArtworkLike.ts
+++ b/src/apis/artwork/deleteArtworkLike.ts
@@ -15,7 +15,7 @@ const deleteArtworkLike = async (postId: number) => {
 
     if (response.status === 204) return true;
 
-    throw new Error('좋아요 취소가 반영되지 않았습니다.');
+    throw new Error('좋아요가 취소되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;

--- a/src/apis/artwork/getArtworkList.ts
+++ b/src/apis/artwork/getArtworkList.ts
@@ -32,8 +32,7 @@ const getArtworkList = async ({
       page: response.data.page,
     };
   } catch (error) {
-    console.error('작품 목록 조회 중 에러 발생: ', error);
-    throw new Error('작품 목록 조회에 실패하였습니다. 다시 시도해주세요.');
+    throw new Error('작품 목록 조회에 실패하였습니다.');
   }
 };
 

--- a/src/apis/artwork/getFollowedArtists.ts
+++ b/src/apis/artwork/getFollowedArtists.ts
@@ -7,10 +7,10 @@ const getFollowedArtists = async () => {
     const response = await authorizedClient.get<FollowedArtistsResponse>(
       ARTWORK.followedArtists,
     );
+
     return response.data.posts;
   } catch (error) {
-    console.error('내가 팔로우한 작가 조회 중 에러 발생: ', error);
-    throw new Error('내가 팔로우한 작가 조회 실패');
+    throw new Error('내가 팔로우한 작가 조회에 실패하였습니다.');
   }
 };
 

--- a/src/apis/artwork/patchArtwork.ts
+++ b/src/apis/artwork/patchArtwork.ts
@@ -15,9 +15,7 @@ const patchArtwork = async (postId: number, data: PatchArtworkData) => {
       {},
     );
 
-    if (Object.keys(updatedData).length === 0) {
-      return null;
-    }
+    if (Object.keys(updatedData).length === 0) return null;
 
     const response = await authorizedClient.patch(
       ARTWORK.patchArtwork(postId),
@@ -26,8 +24,7 @@ const patchArtwork = async (postId: number, data: PatchArtworkData) => {
 
     return response.data.postId;
   } catch (error) {
-    console.error('작품 수정 중 에러 발생: ', error);
-    throw new Error('작품 수정에 실패하였습니다. 다시 시도해주세요.');
+    throw new Error('작품 수정에 실패하였습니다.');
   }
 };
 

--- a/src/apis/artwork/patchArtwork.ts
+++ b/src/apis/artwork/patchArtwork.ts
@@ -1,5 +1,12 @@
+import { isAxiosError } from 'axios';
+
 import { ARTWORK } from '@/constants/API';
+import {
+  ARTWORK_PATCH_ERROR_MESSAGE,
+  COMMON_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
 import { PatchArtworkData } from '@/types';
+import { ErrorResponseType } from '@/types/errorResponse';
 
 import { authorizedClient } from '..';
 
@@ -22,9 +29,23 @@ const patchArtwork = async (postId: number, data: PatchArtworkData) => {
       updatedData,
     );
 
-    return response.data.postId;
-  } catch (error) {
+    if (response.status === 201) {
+      return response.data.postId;
+    }
+
     throw new Error('작품 수정에 실패하였습니다.');
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        throw new Error(ARTWORK_PATCH_ERROR_MESSAGE[code]);
+      } else {
+        throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
   }
 };
 

--- a/src/apis/artwork/patchArtworkComment.ts
+++ b/src/apis/artwork/patchArtworkComment.ts
@@ -17,6 +17,7 @@ const patchArtworkComment = async (commentId: number, content: string) => {
     );
 
     if (response.status === 204) return content;
+
     throw new Error('댓글 수정에 실패하였습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {

--- a/src/apis/artwork/patchArtworkComment.ts
+++ b/src/apis/artwork/patchArtworkComment.ts
@@ -16,24 +16,18 @@ const patchArtworkComment = async (commentId: number, content: string) => {
       { content },
     );
 
-    if (response.status === 204) {
-      return content;
-    } else {
-      throw new Error('댓글 수정 실패');
-    }
+    if (response.status === 204) return content;
+    throw new Error('댓글 수정에 실패하였습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(COMMENT_ERROR_MESSAGE[code]);
         throw new Error(COMMENT_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/artwork/patchArtworkComment.ts
+++ b/src/apis/artwork/patchArtworkComment.ts
@@ -18,7 +18,7 @@ const patchArtworkComment = async (commentId: number, content: string) => {
 
     if (response.status === 204) return content;
 
-    throw new Error('댓글 수정에 실패하였습니다.');
+    throw new Error('댓글이 수정되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;

--- a/src/apis/artwork/postArtwork.ts
+++ b/src/apis/artwork/postArtwork.ts
@@ -18,7 +18,7 @@ const postArtwork = async (artworkData: ArtworkUploadData) => {
 
     return response.data;
   } catch (error) {
-    throw new Error('작품 업로드에 실패하였습니다.');
+    throw new Error('작품이 업로드되지 않았습니다.');
   }
 };
 

--- a/src/apis/artwork/postArtwork.ts
+++ b/src/apis/artwork/postArtwork.ts
@@ -1,5 +1,12 @@
+import { isAxiosError } from 'axios';
+
 import { authorizedClient } from '@/apis';
 import { ARTWORK } from '@/constants/API';
+import {
+  ARTWORK_POST_ERROR_MESSAGE,
+  COMMON_ERROR_MESSAGE,
+} from '@/constants/errorMessage';
+import { ErrorResponseType } from '@/types/errorResponse';
 
 interface ArtworkUploadData {
   title: string;
@@ -16,9 +23,21 @@ const postArtwork = async (artworkData: ArtworkUploadData) => {
       artworkData,
     );
 
-    return response.data;
-  } catch (error) {
+    if (response.status === 201) return response.data;
+
     throw new Error('작품이 업로드되지 않았습니다.');
+  } catch (error) {
+    if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
+      const { code } = error;
+
+      if (code) {
+        throw new Error(ARTWORK_POST_ERROR_MESSAGE[code]);
+      } else {
+        throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
+      }
+    } else {
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+    }
   }
 };
 

--- a/src/apis/artwork/postArtwork.ts
+++ b/src/apis/artwork/postArtwork.ts
@@ -15,10 +15,10 @@ const postArtwork = async (artworkData: ArtworkUploadData) => {
       ARTWORK.uploadArtwork,
       artworkData,
     );
+
     return response.data;
   } catch (error) {
-    console.error('작품 업로드 중 에러 발생: ', error);
-    throw new Error('작품 업로드에 실패하였습니다. 다시 시도해주세요.');
+    throw new Error('작품 업로드에 실패하였습니다.');
   }
 };
 

--- a/src/apis/artwork/postArtworkLike.ts
+++ b/src/apis/artwork/postArtworkLike.ts
@@ -15,24 +15,19 @@ const postArtworkLike = async (postId: number) => {
       ARTWORK.artworkLike(postId),
     );
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('좋아요 요청 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('좋아요가 반영되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(LIKE_ERROR_MESSAGE[code]);
         throw new Error(LIKE_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/artwork/postComment.ts
+++ b/src/apis/artwork/postComment.ts
@@ -23,24 +23,19 @@ const postComment = async ({ postId, content }: PostCommentProps) => {
       },
     );
 
-    if (response.status === 201) {
-      return true;
-    } else {
-      throw new Error('컬랙션 내 작품 추가 요청 실패');
-    }
+    if (response.status === 201) return true;
+
+    throw new Error('댓글이 작성되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(COMMENT_ERROR_MESSAGE[code]);
         throw new Error(COMMENT_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/auth/validateEmail.ts
+++ b/src/apis/auth/validateEmail.ts
@@ -12,6 +12,7 @@ const getValidateEmail = async (email: string) => {
         email,
       },
     });
+
     return response.status;
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response)

--- a/src/apis/auth/validateNickname.ts
+++ b/src/apis/auth/validateNickname.ts
@@ -12,6 +12,7 @@ const getValidateNickname = async (nickname: string) => {
         nickname,
       },
     });
+
     return response.status;
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response)

--- a/src/apis/collection/deleteCollection.ts
+++ b/src/apis/collection/deleteCollection.ts
@@ -15,24 +15,19 @@ const deleteCollection = async (collectionId: number) => {
       COLLECTION.modifyCollection(collectionId),
     );
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('컬렉션 삭제 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('컬렉션 삭제에 실패하였습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(COLLECTION_DELETE_ERROR_MESSAGE[code]);
         throw new Error(COLLECTION_DELETE_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/collection/deleteCollectionArtwork.ts
+++ b/src/apis/collection/deleteCollectionArtwork.ts
@@ -19,24 +19,19 @@ const deleteCollectionArtwork = async ({
       COLLECTION.collectionAddAndRemoveArtwork(collectionId, postId),
     );
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('작품 삭제 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('작품이 삭제되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(ARTWORK_ERROR_MESSAGE[code]);
         throw new Error(ARTWORK_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/collection/getCollectionArtworks.ts
+++ b/src/apis/collection/getCollectionArtworks.ts
@@ -34,14 +34,11 @@ const getCollectionArtworks = async ({
       const { code } = error;
 
       if (code) {
-        console.error(COLLECTION_ARTWORKS_ERROR_MESSAGE[code]);
         throw new Error(COLLECTION_ARTWORKS_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/collection/getProfileCollectionList.ts
+++ b/src/apis/collection/getProfileCollectionList.ts
@@ -32,14 +32,11 @@ const getProfileCollectionList = async ({
       const { code } = error;
 
       if (code) {
-        console.error(PROFILE_COLLECTION_GET_ERROR_MESSAGE[code]);
         throw new Error(PROFILE_COLLECTION_GET_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/collection/patchCollection.ts
+++ b/src/apis/collection/patchCollection.ts
@@ -20,24 +20,19 @@ const patchCollection = async ({
       data,
     );
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('컬렉션 수정 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('컬렉션 수정에 실패하였습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(COLLECTION_PATCH_ERROR_MESSAGE[code]);
         throw new Error(COLLECTION_PATCH_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/collection/patchCollection.ts
+++ b/src/apis/collection/patchCollection.ts
@@ -22,7 +22,7 @@ const patchCollection = async ({
 
     if (response.status === 204) return true;
 
-    throw new Error('컬렉션 수정에 실패하였습니다.');
+    throw new Error('컬렉션이 수정되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;

--- a/src/apis/collection/postCollection.ts
+++ b/src/apis/collection/postCollection.ts
@@ -27,16 +27,13 @@ const postCollection = async ({ name, isPrivate }: PostCollectionProps) => {
       const { code } = error;
 
       if (code) {
-        console.error(COLLECTION_POST_ERROR_MESSAGE[code]);
         throw new Error(COLLECTION_POST_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
       alert('이미 존재하는 컬렉션 이름입니다.');
-      // console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
-      // throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }
 };

--- a/src/apis/collection/postCollection.ts
+++ b/src/apis/collection/postCollection.ts
@@ -32,7 +32,6 @@ const postCollection = async ({ name, isPrivate }: PostCollectionProps) => {
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      alert('이미 존재하는 컬렉션 이름입니다.');
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/collection/postCollectionAddArtwork.ts
+++ b/src/apis/collection/postCollectionAddArtwork.ts
@@ -19,26 +19,21 @@ const postCollectionAddArtwork = async ({
       COLLECTION.collectionAddAndRemoveArtwork(collectionId, postId),
     );
 
-    if (response.status === 201) {
-      return true;
-    } else {
-      throw new Error('컬랙션 내 작품 추가 요청 실패');
-    }
+    if (response.status === 201) return true;
+
+    throw new Error('컬렉션에 작품이 추가되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(COLLECTION_ADD_ARTWORK_ERROR_MESSAGE[code]);
         throw new Error(COLLECTION_ADD_ARTWORK_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
       alert('이미 선택한 컬렉션에 저장한 작품입니다.');
-      // console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
-      // throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
+      throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }
 };

--- a/src/apis/collection/postCollectionAddArtwork.ts
+++ b/src/apis/collection/postCollectionAddArtwork.ts
@@ -5,6 +5,7 @@ import {
   COLLECTION_ADD_ARTWORK_ERROR_MESSAGE,
   COMMON_ERROR_MESSAGE,
 } from '@/constants/errorMessage';
+import useToastStore from '@/stores/useToastStore';
 import { CollectionAddAndRemoveArtworkParams } from '@/types/collection';
 import { ErrorResponseType } from '@/types/errorResponse';
 
@@ -14,6 +15,8 @@ const postCollectionAddArtwork = async ({
   collectionId,
   postId,
 }: CollectionAddAndRemoveArtworkParams) => {
+  const { showToast } = useToastStore();
+
   try {
     const response = await authorizedClient.post<null>(
       COLLECTION.collectionAddAndRemoveArtwork(collectionId, postId),
@@ -32,7 +35,7 @@ const postCollectionAddArtwork = async ({
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      alert('이미 선택한 컬렉션에 저장한 작품입니다.');
+      showToast('error', '이미 선택한 컬렉션에 저장한 작품입니다.');
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/collection/postCollectionAddArtwork.ts
+++ b/src/apis/collection/postCollectionAddArtwork.ts
@@ -21,7 +21,7 @@ const postCollectionAddArtwork = async ({
 
     if (response.status === 201) return true;
 
-    throw new Error('컬렉션에 작품이 추가되지 않았습니다.');
+    throw new Error('작품이 컬렉션에 저장되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;

--- a/src/apis/follow/deleteFollow.ts
+++ b/src/apis/follow/deleteFollow.ts
@@ -15,24 +15,19 @@ const deleteFollow = async (userId: number) => {
       data: { userId },
     });
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('팔로우 취소 요청 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('팔로우가 취소되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(FOLLOW_ERROR_MESSAGE[code]);
         throw new Error(FOLLOW_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/follow/postFollow.ts
+++ b/src/apis/follow/postFollow.ts
@@ -13,24 +13,19 @@ const postFollow = async (userId: number) => {
   try {
     const response = await authorizedClient.post<null>(USER.follow, { userId });
 
-    if (response.status === 204) {
-      return true;
-    } else {
-      throw new Error('팔로우 요청 실패');
-    }
+    if (response.status === 204) return true;
+
+    throw new Error('팔로우가 반영되지 않았습니다.');
   } catch (error) {
     if (isAxiosError<ErrorResponseType<null>>(error) && error.response) {
       const { code } = error;
 
       if (code) {
-        console.error(FOLLOW_ERROR_MESSAGE[code]);
         throw new Error(FOLLOW_ERROR_MESSAGE[code]);
       } else {
-        console.error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(COMMON_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/image/postImage.ts
+++ b/src/apis/image/postImage.ts
@@ -27,7 +27,7 @@ export const postPresignedUrl = async ({
     const { presignedUrl, imageId } = response.data;
 
     if (!(presignedUrl || imageId)) {
-      throw new Error('Presigned URL 또는 Image ID가 누락되었습니다.');
+      console.error('Presigned URL 또는 Image ID가 누락되었습니다.');
     }
 
     return { presignedUrl, imageId };

--- a/src/apis/user/getLikedArtworkList.ts
+++ b/src/apis/user/getLikedArtworkList.ts
@@ -19,11 +19,7 @@ const getLikedArtworkList = async ({
 
     return data;
   } catch (error) {
-    console.error(
-      '프로필 페이지 내 좋아요 작품 리스트 조회 중 에러 발생: ',
-      error,
-    );
-    throw new Error('프로필 페이지 내 좋아요 작품 리스트 조회 실패');
+    throw new Error('좋아요한 작품 목록 조회에 실패하였습니다.');
   }
 };
 

--- a/src/apis/user/getProfileArtworkList.ts
+++ b/src/apis/user/getProfileArtworkList.ts
@@ -20,8 +20,7 @@ const getProfileArtworkList = async ({
 
     return data;
   } catch (error) {
-    console.error('프로필 페이지 내 작품 리스트 조회 중 에러 발생: ', error);
-    throw new Error('프로필 페이지 내 작품 리스트 조회 실패');
+    throw new Error('작품 목록 조회에 실패하였습니다.');
   }
 };
 

--- a/src/apis/user/getProfileInfo.ts
+++ b/src/apis/user/getProfileInfo.ts
@@ -15,8 +15,7 @@ const getProfileInfo = async (userId: number) => {
 
     return data;
   } catch (error) {
-    console.error('작가 정보 조회 중 에러 발생: ', error);
-    throw new Error('작가 정보 조회 실패');
+    throw new Error('작가 정보 조회에 실패하였습니다.');
   }
 };
 

--- a/src/apis/user/patchProfileInfo.ts
+++ b/src/apis/user/patchProfileInfo.ts
@@ -18,7 +18,7 @@ const patchProfileInfo = async (updateInfo: UpdateProfileType) => {
     );
 
     if (response.status !== 204) {
-      throw new Error('프로필 수정 실패');
+      throw new Error('프로필 수정에 실패하였습니다.');
     }
 
     return true;
@@ -27,14 +27,11 @@ const patchProfileInfo = async (updateInfo: UpdateProfileType) => {
       const { code } = error;
 
       if (code) {
-        console.error(EDIT_USER_PROFILE_ERROR_MESSAGE[code]);
         throw new Error(EDIT_USER_PROFILE_ERROR_MESSAGE[code]);
       } else {
-        console.error(EDIT_USER_PROFILE_ERROR_MESSAGE.UNKNOWN_ERROR);
         throw new Error(EDIT_USER_PROFILE_ERROR_MESSAGE.UNKNOWN_ERROR);
       }
     } else {
-      console.error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
       throw new Error(COMMON_ERROR_MESSAGE.NETWORK_ERROR);
     }
   }

--- a/src/apis/user/updateProfileInfo.ts
+++ b/src/apis/user/updateProfileInfo.ts
@@ -17,7 +17,7 @@ const uploadProfileImage = async (imageFile: File): Promise<number> => {
     fileType: imageFile.type,
   });
 
-  if (!presignedData) throw new Error('Presigned URL 요청 실패');
+  if (!presignedData) throw new Error('Presigned URL 요청에 실패하였습니다.');
 
   const { presignedUrl, imageId } = presignedData;
 
@@ -26,7 +26,7 @@ const uploadProfileImage = async (imageFile: File): Promise<number> => {
     uploadUrl: presignedUrl,
   });
 
-  if (!uploadSuccess) throw new Error('이미지 업로드 실패');
+  if (!uploadSuccess) throw new Error('이미지 업로드에 실패하였습니다.');
 
   await putNotifyImageUploadComplete(imageId);
 

--- a/src/app/artwork/detail/page.tsx
+++ b/src/app/artwork/detail/page.tsx
@@ -9,20 +9,26 @@ import ArtworkDetailHeader from '@/components/ArtworkDetailPage/ArtworkDetailHea
 import ArtworkDetailInfoSection from '@/components/ArtworkDetailPage/ArtworkDetailInfoSection';
 import ButtonGroup from '@/components/ArtworkDetailPage/ButtonGroup';
 import useGetArtworkPost from '@/hooks/serverStateHooks/useGetArtworkPost';
+import useToastStore from '@/stores/useToastStore';
 
 const ArtworkDetailPage = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const postId = Number(searchParams.get('postId'));
 
+  const { showToast } = useToastStore();
+
   const {
     headerInfo,
     socialInfo,
     detailInfo,
     artistInfo,
-    isLoading,
     commentCount,
+    isLoading,
+    isError,
   } = useGetArtworkPost(postId);
+
+  if (isError) showToast('error', '작품 조회에 실패하였습니다.');
 
   useEffect(() => {
     if (!postId) router.back();

--- a/src/app/artwork/list/page.tsx
+++ b/src/app/artwork/list/page.tsx
@@ -9,6 +9,7 @@ import ArtworkShowcase from '@/components/ArtworkListPage/ArtworkShowcase';
 import FollowedArtistsSection from '@/components/ArtworkListPage/FollowedArtistsSection';
 import { ARTWORK_SORT_OPTIONS, ITEMS_PER_PAGE } from '@/constants/pagination';
 import useGetArtworkList from '@/hooks/serverStateHooks/useGetArtworkList';
+import useToastStore from '@/stores/useToastStore';
 
 const ArtworkList = () => {
   const router = useRouter();
@@ -20,12 +21,14 @@ const ArtworkList = () => {
   const [selectedOption, setSelectedOption] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
 
+  const { showToast } = useToastStore();
+
   const sortValue = ARTWORK_SORT_OPTIONS[selectedOption] || 'recent';
 
   const {
     data: artworkList,
     isLoading: artworkListLoading,
-    error: artworkListError,
+    isError: artworkListError,
   } = useGetArtworkList({
     sort: sortValue,
     artworkField:
@@ -40,6 +43,7 @@ const ArtworkList = () => {
   }
 
   if (artworkListError) {
+    showToast('error', '작품 목록 조회에 실패하였습니다.');
     return <p className='px-[36px] lg:px-[140px]'>데이터 로드 중 오류 발생</p>;
   }
 

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -153,7 +153,9 @@ const ArtworkUpload = () => {
 
   const { mutate: patchArtwork } = usePatchArtwork();
 
-  const { existingArtwork } = useGetArtworkPost(parsedPostId);
+  const { existingArtwork, isError } = useGetArtworkPost(parsedPostId);
+
+  if (isError) showToast('error', '수정할 작품 조회에 실패하였습니다.');
 
   useEffect(() => {
     if (existingArtwork && !existingArtworkRef.current) {

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -124,7 +124,7 @@ const ArtworkUpload = () => {
       newErrors.artworkTitleError = REQUIRED_FIELDS_ERROR_MESSAGE;
     if (!selectedArtworkField.trim())
       newErrors.selectedArtworkFieldError = REQUIRED_FIELDS_ERROR_MESSAGE;
-    if (!(isEditMode && uploadedImage))
+    if (!isEditMode && !uploadedImage)
       newErrors.uploadedImageError = REQUIRED_FIELDS_ERROR_MESSAGE;
 
     setErrors(newErrors);

--- a/src/app/artwork/upload/page.tsx
+++ b/src/app/artwork/upload/page.tsx
@@ -14,6 +14,7 @@ import useGetArtworkPost from '@/hooks/serverStateHooks/useGetArtworkPost';
 import usePatchArtwork from '@/hooks/serverStateHooks/usePatchArtwork';
 import usePostArtwork from '@/hooks/serverStateHooks/usePostArtwork';
 import modalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/useToastStore';
 import { ArtworkFieldsErrors, PatchArtworkData } from '@/types';
 
 import Textarea from '../../../components/Input/Textarea';
@@ -55,6 +56,8 @@ const ArtworkUpload = () => {
   const parsedPostId = postId ? parseInt(postId, 10) : null;
   const isEditMode = Boolean(postId);
   const existingArtworkRef = useRef<PatchArtworkData | null>(null);
+
+  const { showToast } = useToastStore();
 
   const handleArtworkDescriptionOnChange = (
     e: ChangeEvent<HTMLTextAreaElement>,
@@ -128,11 +131,11 @@ const ArtworkUpload = () => {
     return Object.keys(newErrors).length === 0;
   };
 
-  const { mutate: postArtwork, isError: postArtworkError } = usePostArtwork();
+  const { mutate: postArtwork } = usePostArtwork();
 
   const handleArtworkUpload = () => {
     if (!uploadedImage) {
-      console.error('이미지가 업로드되지 않았습니다.');
+      showToast('error', '이미지가 업로드되지 않았습니다.');
       return;
     }
 
@@ -148,8 +151,7 @@ const ArtworkUpload = () => {
     postArtwork(uploadedArtworkData);
   };
 
-  const { mutate: patchArtwork, isError: patchArtworkError } =
-    usePatchArtwork();
+  const { mutate: patchArtwork } = usePatchArtwork();
 
   const { existingArtwork } = useGetArtworkPost(parsedPostId);
 
@@ -235,13 +237,6 @@ const ArtworkUpload = () => {
 
   return (
     <div className='max-w-[1920px] m-auto px-[36px] py-[70px] lg:px-[140px]'>
-      {/* {toastMessage && (
-          <ToastPopup
-            message={toastMessage}
-            onClose={() => setToastMessage(null)}
-          />
-        )} */}
-
       <h1>작품 업로드</h1>
       <div className='pt-[70px] pb-[58px] md:pb-[40px]'>
         <BasicInput
@@ -323,9 +318,6 @@ const ArtworkUpload = () => {
             {isEditMode ? '수정' : '업로드'}
           </button>
         )}
-
-        {postArtworkError && <p>[업로드 실패] 다시 시도해 주세요.</p>}
-        {patchArtworkError && <p>[수정 실패] 다시 시도해 주세요.</p>}
       </div>
     </div>
   );

--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -17,11 +17,14 @@ import { ARTWORK_SORT_OPTIONS, ITEMS_PER_PAGE } from '@/constants/pagination';
 import useDeleteCollection from '@/hooks/serverStateHooks/useDeleteCollection';
 import useGetCollectionArtworks from '@/hooks/serverStateHooks/useGetCollectionArtworks';
 import modalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/useToastStore';
 
 const Collection = () => {
   const [selectedOption, setSelectedOption] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
+
   const { openModal, closeModal } = useStore(modalStore);
+  const { showToast } = useToastStore();
 
   const collectionIdParams = useSearchParams().get('collectionId');
   const collectionId = collectionIdParams ? Number(collectionIdParams) : 0;
@@ -30,18 +33,22 @@ const Collection = () => {
   };
 
   const queryClient = useQueryClient();
+
   const {
     isMine,
     name: collectionName,
     artworks,
     pageInfo,
     isLoading,
+    isError,
   } = useGetCollectionArtworks({
     sort: ARTWORK_SORT_OPTIONS[selectedOption] || 'recent',
     page: currentPage - 1,
     size: ITEMS_PER_PAGE,
     collectionId,
   });
+
+  if (isError) showToast('error', '작품 목록 조회에 실패하였습니다.');
 
   const artworksLength = pageInfo.totalDataCnt;
   const router = useRouter();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import '../styles/globals.css';
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
 
+import ToastPopup from '@/components/ToastPopup';
+
 import AppShell from '../components/Layout/AppShell';
 import { montserrat, pretendard } from './fonts';
 import KakaoProvider from './providers/KakaoProvider';
@@ -24,7 +26,10 @@ const RootLayout = ({ children }: Readonly<LayoutProps>) => {
       <body className={`${pretendard} ${montserrat.variable}`}>
         <MSWProvider>
           <TanStackQueryProvider>
-            <AppShell>{children}</AppShell>
+            <AppShell>
+              <ToastPopup />
+              {children}
+            </AppShell>
           </TanStackQueryProvider>
         </MSWProvider>
         <KakaoProvider />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,8 +3,6 @@ import '../styles/globals.css';
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
 
-import ToastPopup from '@/components/ToastPopup';
-
 import AppShell from '../components/Layout/AppShell';
 import { montserrat, pretendard } from './fonts';
 import KakaoProvider from './providers/KakaoProvider';
@@ -26,10 +24,7 @@ const RootLayout = ({ children }: Readonly<LayoutProps>) => {
       <body className={`${pretendard} ${montserrat.variable}`}>
         <MSWProvider>
           <TanStackQueryProvider>
-            <AppShell>
-              <ToastPopup />
-              {children}
-            </AppShell>
+            <AppShell>{children}</AppShell>
           </TanStackQueryProvider>
         </MSWProvider>
         <KakaoProvider />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 
 import UserInfoSection from '@/components/ProfilePage/UserInfoSection';
 import useGetProfileInfo from '@/hooks/serverStateHooks/useGetProfileInfo';
+import useToastStore from '@/stores/useToastStore';
 
 import UserArtworkSection from '../../components/ProfilePage/UserArtworkSection';
 
@@ -11,9 +12,13 @@ const ProfilePage = () => {
   const searchParams = useSearchParams();
   const userIdParam = searchParams.get('userId');
   const userId = userIdParam ? Number(userIdParam) : null;
-  const { userInfo, isLoading } = useGetProfileInfo(userId);
+
+  const { userInfo, isLoading, isError } = useGetProfileInfo(userId);
+  const { showToast } = useToastStore();
 
   if (isLoading) return <div>Loading</div>;
+
+  if (isError) showToast('error', '프로필 정보 조회에 실패하였습니다.');
 
   return (
     <div className='flex flex-col flex-grow gap-[70px] w-full max-w-[1920px] m-auto py-[70px] px-[32px]'>

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentDefault.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentDefault.tsx
@@ -26,9 +26,6 @@ const CommentDefault = ({
         queryClient.invalidateQueries({
           queryKey: [ARTWORK.artworkPostComments(postId)],
         });
-
-        // 토스트 메세지로 수정
-        alert('댓글 삭제 성공');
       },
     });
   };

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentEdit.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/ArtworkCommentUnit/CommentEdit.tsx
@@ -40,9 +40,6 @@ const CommentEdit = ({
             queryKey: [ARTWORK.artworkPostComments(postId)],
           });
           setIsEditMode(false);
-
-          // 토스트 메세지 적용
-          alert('댓글 수정 성공');
         },
       },
     );

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/index.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/index.tsx
@@ -33,7 +33,7 @@ const ArtworkCommentSection = ({
     commentData === undefined ||
     commentData?.pages.flatMap((page) => page.comments).length === 0;
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) return <div>로딩 중...</div>;
 
   return (
     <div className='flex-1 flex flex-col gap-5'>

--- a/src/components/ArtworkDetailPage/ArtworkCommentSection/index.tsx
+++ b/src/components/ArtworkDetailPage/ArtworkCommentSection/index.tsx
@@ -4,6 +4,7 @@ import { Fragment } from 'react';
 
 import Icon from '@/components/Icon/Icon';
 import useGetArtworkComments from '@/hooks/serverStateHooks/useGetArtworkComments';
+import useToastStore from '@/stores/useToastStore';
 
 import ArtworkCommentUnit from './ArtworkCommentUnit';
 import ArtworkWriteCommentSection from './ArtworkWriteCommentSection';
@@ -17,13 +18,16 @@ const ArtworkCommentSection = ({
   postId,
   commentCount,
 }: ArtworkCommentSectionProps) => {
+  const { showToast } = useToastStore();
+
   const {
     commentData,
-    isLoading,
     hasNextPage,
     lastCommentRef,
     observerActive,
     activeObserver,
+    isLoading,
+    isError,
   } = useGetArtworkComments({
     postId,
     skip: 0,
@@ -34,6 +38,8 @@ const ArtworkCommentSection = ({
     commentData?.pages.flatMap((page) => page.comments).length === 0;
 
   if (isLoading) return <div>로딩 중...</div>;
+
+  if (isError) showToast('error', '댓글 조회에 실패하였습니다.');
 
   return (
     <div className='flex-1 flex flex-col gap-5'>

--- a/src/components/ArtworkListPage/FollowedArtistsSection.tsx
+++ b/src/components/ArtworkListPage/FollowedArtistsSection.tsx
@@ -15,10 +15,10 @@ import ArtworkCard from '../Card/ArtworkCard';
 import Icon from '../Icon/Icon';
 
 const FollowedArtistsSection = () => {
-  const router = useRouter();
   const [showFollowedArtistsCards, setShowFollowedArtistsCards] =
     useState(true);
 
+  const router = useRouter();
   const accessToken = TokenHandler.getAccessToken();
 
   const {

--- a/src/components/ArtworkListPage/FollowedArtistsSection.tsx
+++ b/src/components/ArtworkListPage/FollowedArtistsSection.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import DefaultCarousel from '@/components/Carousel/DefaultCarousel';
 import ROUTE from '@/constants/routes';
 import useGetFollowedArtists from '@/hooks/serverStateHooks/useGetFollowedArtists';
+import useToastStore from '@/stores/useToastStore';
 import { ArtworkInfoType, FollowedArtist } from '@/types';
 import TokenHandler from '@/utils/tokenHandler';
 
@@ -21,10 +22,12 @@ const FollowedArtistsSection = () => {
   const router = useRouter();
   const accessToken = TokenHandler.getAccessToken();
 
+  const { showToast } = useToastStore();
+
   const {
     data: followedArtists,
     isLoading: followedArtistsLoading,
-    error: followedArtistsError,
+    isError: followedArtistsError,
   } = useGetFollowedArtists();
 
   const clickUserInfo = (userId: number) => {
@@ -45,6 +48,10 @@ const FollowedArtistsSection = () => {
       return newState;
     });
   };
+
+  if (followedArtistsError) {
+    showToast('error', '내가 팔로우한 작가 목록 조회에 실패하였습니다.');
+  }
 
   return (
     <>
@@ -73,8 +80,6 @@ const FollowedArtistsSection = () => {
             </div>
           ) : followedArtistsLoading ? (
             <p className='px-[36px] lg:px-[140px]'>데이터 로딩 중...</p>
-          ) : followedArtistsError ? (
-            <p className='px-[36px] lg:px-[140px]'>데이터 로드 중 오류 발생</p>
           ) : !followedArtists.length ? (
             <div
               className='grid flex-col col-span-full items-center justify-center

--- a/src/components/ArtworkUploadPage/ImageUploadSection.tsx
+++ b/src/components/ArtworkUploadPage/ImageUploadSection.tsx
@@ -89,11 +89,12 @@ const ImageUploadSection = ({
     if (imageFile) {
       setUploadedImage(imageFile);
       uploadImage(imageFile);
-      if (errors.uploadedImageError) clearErrorMessage('uploadedImageError');
     }
   };
 
   const handleImageUpload = async (e: ChangeEvent<HTMLInputElement>) => {
+    if (errors.uploadedImageError) clearErrorMessage('uploadedImageError');
+
     if (e.target.files && e.target.files[0]) {
       if (uploadedImage) {
         setErrors((prevErrors) => ({

--- a/src/components/ArtworkUploadPage/ImageUploadSection.tsx
+++ b/src/components/ArtworkUploadPage/ImageUploadSection.tsx
@@ -103,8 +103,6 @@ const ImageUploadSection = ({
         return;
       }
 
-      if (errors.uploadedImageError) clearErrorMessage('uploadedImageError');
-
       const imageFile = e.target.files[0];
       setUploadedImage(imageFile);
       uploadImage(imageFile);
@@ -115,6 +113,11 @@ const ImageUploadSection = ({
     if (fileInputRef.current) {
       fileInputRef.current.click();
     }
+  };
+
+  const ClickChangeImageBtn = () => {
+    if (errors.uploadedImageError) clearErrorMessage('uploadedImageError');
+    setUploadedImage(null);
   };
 
   return (
@@ -148,7 +151,7 @@ const ImageUploadSection = ({
           {isEditMode ? null : (
             <button
               aria-label='Button to change artwork image'
-              onClick={() => setUploadedImage(null)}
+              onClick={ClickChangeImageBtn}
               className='absolute group flex items-center justify-center w-[57px] h-[57px] md:w-[77px] md:h-[77px]
               right-[30px] bottom-[30px] rounded-full
               bg-[rgba(35,34,37,0.5)] backdrop-blur-[12px]

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -8,6 +8,8 @@ import ModalProvider from '@/app/providers/ModalProvider';
 import Footer from '@/components/Footer';
 import Navbar from '@/components/Navbar';
 
+import ToastPopup from '../ToastPopup';
+
 const AppShell = ({ children }: { children: ReactNode }) => {
   return (
     <>
@@ -20,6 +22,7 @@ const AppShell = ({ children }: { children: ReactNode }) => {
           }}
         >
           <div className='box-border h-full'>
+            <ToastPopup />
             <Navbar />
             <main className='pt-[90px] min-h-full'>{children}</main>
             <Footer />

--- a/src/components/MainPage/LatestArtworkSection.tsx
+++ b/src/components/MainPage/LatestArtworkSection.tsx
@@ -15,7 +15,7 @@ const LatestArtworkSection = () => {
     size: 10,
   });
 
-  if (isLoading) return <div>로딩중</div>;
+  if (isLoading) return <div>로딩 중...</div>;
 
   return (
     <div className='flex flex-col gap-[90px]'>

--- a/src/components/MainPage/LatestArtworkSection.tsx
+++ b/src/components/MainPage/LatestArtworkSection.tsx
@@ -1,13 +1,17 @@
 import useGetArtworkList from '@/hooks/serverStateHooks/useGetArtworkList';
+import useToastStore from '@/stores/useToastStore';
 import { ArtworkInfoType } from '@/types';
 
 import ArtworkCard from '../Card/ArtworkCard';
 import ControlledCarousel from '../Carousel/ControllableCarousel';
 
 const LatestArtworkSection = () => {
+  const { showToast } = useToastStore();
+
   const {
     data: { data: artwork },
     isLoading,
+    isError,
   } = useGetArtworkList({
     sort: 'recent',
     search: '',
@@ -16,6 +20,8 @@ const LatestArtworkSection = () => {
   });
 
   if (isLoading) return <div>로딩 중...</div>;
+
+  if (isError) showToast('error', '작품 목록 조회에 실패하였습니다.');
 
   return (
     <div className='flex flex-col gap-[90px]'>

--- a/src/components/Modal/CollectionModal/index.tsx
+++ b/src/components/Modal/CollectionModal/index.tsx
@@ -7,15 +7,20 @@ import { useStore } from 'zustand';
 import Icon from '@/components/Icon/Icon';
 import useGetAllCollectionList from '@/hooks/serverStateHooks/useGetAllCollectionList';
 import modalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/useToastStore';
 
 import CollectionUnit from './CollectionUnit';
 import CreateCollectionUnit from './CreateCollectionUnit';
 
 const CollectionModal = () => {
   const { closeModal } = useStore(modalStore);
-  const { collections, isLoading } = useGetAllCollectionList();
+  const { showToast } = useToastStore();
+
+  const { collections, isLoading, isError } = useGetAllCollectionList();
 
   if (isLoading) return <div>Loading</div>;
+
+  if (isError) showToast('error', '컬렉션 목록 조회에 실패하였습니다.');
 
   return (
     <div className='flex flex-col gap-[50px] tablet:pl-[56px] tablet:pr-[22px] px-[18px] py-[50px]'>

--- a/src/components/Modal/FollowInfoModal/FollowerList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowerList.tsx
@@ -6,7 +6,7 @@ import useGetFollowerList from '@/hooks/serverStateHooks/useGetFollowerList';
 const FollowerList = ({ nickname }: { nickname: string }) => {
   const { followerList, isLoading } = useGetFollowerList();
 
-  if (isLoading) return <div>isLoading</div>;
+  if (isLoading) return <div>로딩 중...</div>;
 
   return (
     <>

--- a/src/components/Modal/FollowInfoModal/FollowerList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowerList.tsx
@@ -2,11 +2,15 @@
 
 import FollowUserUnit from '@/components/Modal/FollowInfoModal/FollowUserUnit';
 import useGetFollowerList from '@/hooks/serverStateHooks/useGetFollowerList';
+import useToastStore from '@/stores/useToastStore';
 
 const FollowerList = ({ nickname }: { nickname: string }) => {
-  const { followerList, isLoading } = useGetFollowerList();
+  const { followerList, isLoading, isError } = useGetFollowerList();
+  const { showToast } = useToastStore();
 
   if (isLoading) return <div>로딩 중...</div>;
+
+  if (isError) showToast('error', '팔로워 목록 조회에 실패하였습니다.');
 
   return (
     <>

--- a/src/components/Modal/FollowInfoModal/FollowingList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowingList.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import useGetFollowingList from '@/hooks/serverStateHooks/useGetFollowingList';
+import useToastStore from '@/stores/useToastStore';
 
 import FollowUserUnit from './FollowUserUnit';
 
 const FollowingList = ({ nickname }: { nickname: string }) => {
-  const { followingList, isLoading } = useGetFollowingList();
+  const { showToast } = useToastStore();
+  const { followingList, isLoading, isError } = useGetFollowingList();
 
   if (isLoading) return <div>로딩 중...</div>;
+
+  if (isError) showToast('error', '팔로잉 목록 조회에 실패하였습니다.');
 
   return (
     <>

--- a/src/components/Modal/FollowInfoModal/FollowingList.tsx
+++ b/src/components/Modal/FollowInfoModal/FollowingList.tsx
@@ -7,7 +7,7 @@ import FollowUserUnit from './FollowUserUnit';
 const FollowingList = ({ nickname }: { nickname: string }) => {
   const { followingList, isLoading } = useGetFollowingList();
 
-  if (isLoading) return <div>Loading...</div>;
+  if (isLoading) return <div>로딩 중...</div>;
 
   return (
     <>

--- a/src/components/Navbar/NavbarUserOption.tsx
+++ b/src/components/Navbar/NavbarUserOption.tsx
@@ -5,14 +5,19 @@ import { useState } from 'react';
 import ROUTE from '@/constants/routes';
 import useClickOutside from '@/hooks/clientStateHooks/useClickOutside';
 import useGetProfileInfo from '@/hooks/serverStateHooks/useGetProfileInfo';
+import useToastStore from '@/stores/useToastStore';
 import TokenHandler from '@/utils/tokenHandler';
 
 const NavbarUserOption = () => {
-  const router = useRouter();
   const [toggleOptionArea, setToggleOptionArea] = useState(false);
 
+  const router = useRouter();
   const userId = TokenHandler.getUserIdFromToken();
-  const { userInfo } = useGetProfileInfo(userId);
+
+  const { userInfo, isError } = useGetProfileInfo(userId);
+  const { showToast } = useToastStore();
+
+  if (isError) showToast('error', '프로필 정보 조회에 실패하였습니다.');
 
   const targetRef = useClickOutside<HTMLDivElement>(() => {
     setToggleOptionArea(false);

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -101,7 +101,6 @@ const Navbar = () => {
               작품
             </li>
             <li className='hover:text-gray-300 cursor-pointer'>전시회</li>
-            <li className='hover:text-gray-300 cursor-pointer'>커뮤니티</li>
           </ul>
           <div className='flex justify-end item-center gap-[50px] justify-items-end'>
             {isSignedIn && <NavbarNoticeDetail />}
@@ -189,9 +188,6 @@ const Navbar = () => {
                   </li>
                   <li className='hover:text-gray-300 cursor-pointer px-10 py-8'>
                     전시회
-                  </li>
-                  <li className='hover:text-gray-300 cursor-pointer px-10 py-8'>
-                    커뮤니티
                   </li>
                 </ul>
               </div>

--- a/src/components/ProfilePage/UserArtworkSection/ArtworkTab.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/ArtworkTab.tsx
@@ -11,6 +11,7 @@ import { ARTWORK_SORT_OPTIONS, ITEMS_PER_PAGE } from '@/constants/pagination';
 import ROUTE from '@/constants/routes';
 import { SORT_OPTIONS } from '@/constants/sortOptions';
 import useGetProfileArtworkList from '@/hooks/serverStateHooks/useGetProfileArtworkList';
+import useToastStore from '@/stores/useToastStore';
 
 const ArtworkTab = () => {
   const router = useRouter();
@@ -21,12 +22,16 @@ const ArtworkTab = () => {
   const [currentSort, setCurrentSort] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
 
-  const { isMine, artworkList, pageInfo } = useGetProfileArtworkList({
+  const { showToast } = useToastStore();
+
+  const { isMine, artworkList, pageInfo, isError } = useGetProfileArtworkList({
     sort: ARTWORK_SORT_OPTIONS[currentSort] || 'recent',
     page: currentPage - 1,
     size: ITEMS_PER_PAGE,
     userId,
   });
+
+  if (isError) showToast('error', '작품 목록 조회에 실패하였습니다.');
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);

--- a/src/components/ProfilePage/UserArtworkSection/CollectionTab.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/CollectionTab.tsx
@@ -15,12 +15,14 @@ import {
 } from '@/constants/pagination';
 import useGetProfileCollectionList from '@/hooks/serverStateHooks/useGetProfileCollectionList';
 import modalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/useToastStore';
 
 const CollectionTab = () => {
   const [selectedOption, setSelectedOption] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
 
   const { openModal, closeModal } = useStore(modalStore);
+  const { showToast } = useToastStore();
 
   const params = useSearchParams();
   const userIdParams = params.get('userId');
@@ -38,13 +40,15 @@ const CollectionTab = () => {
     });
   };
 
-  const { isMine, collections, pageInfo, isLoading } =
+  const { isMine, collections, pageInfo, isLoading, isError } =
     useGetProfileCollectionList({
       sort: COLLECTION_SORT_OPTIONS[selectedOption] || 'recent',
       page: currentPage - 1,
       size: ITEMS_PER_PAGE,
       userId,
     });
+
+  if (isError) showToast('error', '컬렉션 목록 조회에 실패하였습니다.');
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);

--- a/src/components/ProfilePage/UserArtworkSection/CollectionTab.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/CollectionTab.tsx
@@ -19,6 +19,7 @@ import modalStore from '@/stores/modalStore';
 const CollectionTab = () => {
   const [selectedOption, setSelectedOption] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
+
   const { openModal, closeModal } = useStore(modalStore);
 
   const params = useSearchParams();

--- a/src/components/ProfilePage/UserArtworkSection/LikedTab.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/LikedTab.tsx
@@ -11,18 +11,23 @@ import { ARTWORK_SORT_OPTIONS, ITEMS_PER_PAGE } from '@/constants/pagination';
 import ROUTE from '@/constants/routes';
 import { SORT_OPTIONS } from '@/constants/sortOptions';
 import useGetLikedArtworkList from '@/hooks/serverStateHooks/useGetLikedArtworkList';
+import useToastStore from '@/stores/useToastStore';
 
 const LikedTab = () => {
   const [currentSort, setCurrentSort] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
 
+  const { showToast } = useToastStore();
+
   const router = useRouter();
 
-  const { artworkList, pageInfo } = useGetLikedArtworkList({
+  const { artworkList, pageInfo, isError } = useGetLikedArtworkList({
     sort: ARTWORK_SORT_OPTIONS[currentSort] || 'recent',
     page: currentPage - 1,
     size: ITEMS_PER_PAGE,
   });
+
+  if (isError) showToast('error', '좋아요한 작품 목록 조회에 실패하였습니다.');
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);

--- a/src/components/ProfilePage/UserArtworkSection/LikedTab.tsx
+++ b/src/components/ProfilePage/UserArtworkSection/LikedTab.tsx
@@ -13,9 +13,10 @@ import { SORT_OPTIONS } from '@/constants/sortOptions';
 import useGetLikedArtworkList from '@/hooks/serverStateHooks/useGetLikedArtworkList';
 
 const LikedTab = () => {
-  const router = useRouter();
   const [currentSort, setCurrentSort] = useState('최신순');
   const [currentPage, setCurrentPage] = useState(1);
+
+  const router = useRouter();
 
   const { artworkList, pageInfo } = useGetLikedArtworkList({
     sort: ARTWORK_SORT_OPTIONS[currentSort] || 'recent',

--- a/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
+++ b/src/components/ProfilePage/UserInfoSection/EditUserInfo.tsx
@@ -116,7 +116,6 @@ const EditUserInfo = ({
 
     updateUserProfile(newProfileData, {
       onSuccess: () => {
-        alert('프로필이 성공적으로 업데이트되었습니다!');
         toggleEditMode();
       },
     });

--- a/src/components/ToastPopup/index.tsx
+++ b/src/components/ToastPopup/index.tsx
@@ -6,13 +6,13 @@ import useToastStore from '@/stores/useToastStore';
 
 import Icon from '../Icon/Icon';
 
-const SPACING = 3;
+const SPACING = 48;
 
 const ToastPopup = () => {
   const { toasts } = useToastStore();
 
-  return toasts.length ? (
-    <div className='fixed top-10 left-1/2 transform -translate-x-1/2 z-50 flex flex-col items-center space-y-2'>
+  return (
+    <div className='fixed top-10 left-1/2 transform -translate-x-1/2 z-50 flex flex-col items-center'>
       <AnimatePresence>
         {toasts.map((toast, index) => (
           <motion.div
@@ -22,6 +22,10 @@ const ToastPopup = () => {
             animate={{ opacity: 1, y: index * SPACING }}
             exit={{ opacity: 0, y: 10 + index * SPACING }}
             transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+            style={{
+              position: 'absolute',
+              top: index === 0 ? 0 : index * SPACING,
+            }}
             className='button-m text-white bg-background-overlay
             w-[366px] mobile:w-[698px] tablet:w-[916px] p-[30px] rounded-[10px]
             shadow-md flex items-center'
@@ -44,7 +48,7 @@ const ToastPopup = () => {
         ))}
       </AnimatePresence>
     </div>
-  ) : null;
+  );
 };
 
 export default ToastPopup;

--- a/src/components/ToastPopup/index.tsx
+++ b/src/components/ToastPopup/index.tsx
@@ -6,23 +6,25 @@ import useToastStore from '@/stores/useToastStore';
 
 import Icon from '../Icon/Icon';
 
+const SPACING = 3;
+
 const ToastPopup = () => {
   const { toasts } = useToastStore();
 
   return toasts.length ? (
-    <div
-      className='button-m text-white bg-background-overlay
-      w-[366px] mobile:w-[698px] tablet:w-[916px] p-[30px] rounded-[10px]
-      fixed top-10 left-1/2 transform -translate-x-1/2 z-50'
-    >
+    <div className='fixed top-10 left-1/2 transform -translate-x-1/2 z-50 flex flex-col items-center space-y-2'>
       <AnimatePresence>
-        {toasts.map((toast) => (
+        {toasts.map((toast, index) => (
           <motion.div
             key={toast.id}
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 10 }}
-            className='flex items-center'
+            layout
+            initial={{ opacity: 0, y: 10 + index * SPACING }}
+            animate={{ opacity: 1, y: index * SPACING }}
+            exit={{ opacity: 0, y: 10 + index * SPACING }}
+            transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+            className='button-m text-white bg-background-overlay
+            w-[366px] mobile:w-[698px] tablet:w-[916px] p-[30px] rounded-[10px]
+            shadow-md flex items-center'
           >
             {toast.type === 'error' ? (
               <Icon

--- a/src/components/ToastPopup/index.tsx
+++ b/src/components/ToastPopup/index.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import useToastStore from '@/stores/useToastStore';
+
+import Icon from '../Icon/Icon';
+
+const ToastPopup = () => {
+  const { toasts } = useToastStore();
+
+  return toasts.length ? (
+    <div
+      className='button-m text-white bg-background-overlay
+      w-[366px] mobile:w-[698px] tablet:w-[916px] p-[30px] rounded-[10px]
+      fixed top-10 left-1/2 transform -translate-x-1/2 z-50'
+    >
+      <AnimatePresence>
+        {toasts.map((toast) => (
+          <motion.div
+            key={toast.id}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            className='flex items-center'
+          >
+            {toast.type === 'error' ? (
+              <Icon
+                name='AlertCircle'
+                size='l'
+                className='text-system-error mr-7 shrink-0'
+              />
+            ) : (
+              <Icon
+                name='CheckCircleFilled'
+                size='l'
+                className='text-system-success mr-7 shrink-0'
+              />
+            )}
+            <p>{toast.message}</p>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  ) : null;
+};
+
+export default ToastPopup;

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -48,10 +48,30 @@ export const ARTWORK_ERROR_MESSAGE: MessageConstantType = {
   ARTWORK_POST_NOT_FOUND: '리소스를 찾을 수 없습니다.',
 };
 
+export const ARTWORK_POST_ERROR_MESSAGE: MessageConstantType = {
+  INVALID_PARAMETER: '요청한 정보가 올바르지 않습니다.',
+  INVALID_ARTWORK_TITLE: '제목을 1자 이상 50자 이하로 입력해 주세요.',
+  INVALID_ARTWORK_FIELD: '카테고리를 올바르게 지정해 주세요.',
+  INVALID_STATUS: '공개 여부를 올바르게 지정해 주세요.',
+  IMAGE_NOT_FOUND: '이미지 정보가 올바르지 않습니다.',
+  INVALID_ARTWORK_EXPLANATION: '설명을 1000자 이하로 입력해 주세요.',
+};
+
+export const ARTWORK_PATCH_ERROR_MESSAGE: MessageConstantType = {
+  INVALID_PARAMETER: '요청한 정보가 올바르지 않습니다.',
+  INVALID_ARTWORK_TITLE: '제목을 1자 이상 50자 이하로 입력해 주세요.',
+  INVALID_ARTWORK_FIELD: '카테고리를 올바르게 지정해 주세요.',
+  INVALID_STATUS: '공개 여부를 올바르게 지정해 주세요.',
+  INVALID_ARTWORK_EXPLANATION: '설명을 1000자 이하로 입력해 주세요.',
+  NOT_OWNER: '본인의 작품이 아닙니다.',
+};
+
 export const COMMENT_ERROR_MESSAGE: MessageConstantType = {
+  INVALID_PARAMETER: '요청한 정보가 올바르지 않습니다.',
   NOT_OWNER: '본인의 댓글이 아닙니다.',
   COMMENT_NOT_FOUND: '리소스를 찾을 수 없습니다.',
-  INVALID_COMMENT_CONTENT: '입력 정보가 올바르지 않습니다.',
+  INVALID_COMMENT_CONTENT:
+    '댓글은 최소 1자 이상의 문자를 포함해야 하며, 공백만으로 구성된 내용은 입력할 수 없습니다.',
   POST_NOT_FOUND: '요청한 리소스를 찾을 수 없습니다.',
   NOT_AUTHORIZED: '댓글에 대한 권한이 없습니다.',
 };
@@ -69,7 +89,10 @@ export const PROFILE_COLLECTION_GET_ERROR_MESSAGE: MessageConstantType = {
 };
 
 export const COLLECTION_POST_ERROR_MESSAGE: MessageConstantType = {
-  INVALID_COLLECTION_NAME: 'name이 비어 있거나 글자 수 제한이 위반되었습니다.',
+  INVALID_PARAMETER: '요청한 정보가 올바르지 않습니다.',
+  INVALID_COLLECTION_NAME: '컬렉션 이름을 1자 이상 10자 이하로 입력해 주세요.',
+  INVALID_STATUS: '공개 여부를 올바르게 지정해 주세요.',
+  DUPLICATE_COLLECTION_NAME: '이미 존재하는 컬렉션 이름입니다.',
 };
 
 export const COLLECTION_DELETE_ERROR_MESSAGE: MessageConstantType = {
@@ -78,10 +101,12 @@ export const COLLECTION_DELETE_ERROR_MESSAGE: MessageConstantType = {
 };
 
 export const COLLECTION_PATCH_ERROR_MESSAGE: MessageConstantType = {
+  INVALID_PARAMETER: '요청한 정보가 올바르지 않습니다.',
+  INVALID_COLLECTION_NAME: '컬렉션 이름을 1자 이상 10자 이하로 입력해 주세요.',
   INVALID_STATUS: '요청한 status가 잘못되었거나 유효하지 않습니다.',
-  INVALID_COLLECTION_NAME: 'name이 비어 있거나 글자 수 제한이 위반되었습니다.',
   NO_PERMISSION: '본인의 컬렉션이 아닙니다.',
-  COLLECTION_NOT_FOUND: '컬렉션 리소스를 찾을 수 없습니다.',
+  NOT_FOUND: '컬렉션 리소스를 찾을 수 없습니다.',
+  DUPLICATE_COLLECTION_NAME: '이미 존재하는 컬렉션 이름입니다.',
 };
 
 export const COLLECTION_ARTWORKS_ERROR_MESSAGE: MessageConstantType = {

--- a/src/hooks/serverStateHooks/useDeleteArtwork.ts
+++ b/src/hooks/serverStateHooks/useDeleteArtwork.ts
@@ -1,10 +1,23 @@
 import { useMutation } from '@tanstack/react-query';
 
 import deleteArtwork from '@/apis/artwork/deleteArtwork';
+import useToastStore from '@/stores/useToastStore';
 
 const useDeleteArtwork = () => {
+  const { showToast } = useToastStore();
+
   const { mutate } = useMutation({
     mutationFn: (postId: number) => deleteArtwork(postId),
+    onSuccess: () => showToast('success', '작품이 삭제되었습니다.'),
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '작품이 삭제되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
+    },
   });
 
   return { mutate };

--- a/src/hooks/serverStateHooks/useDeleteCollection.ts
+++ b/src/hooks/serverStateHooks/useDeleteCollection.ts
@@ -1,10 +1,23 @@
 import { useMutation } from '@tanstack/react-query';
 
 import deleteCollection from '@/apis/collection/deleteCollection';
+import useToastStore from '@/stores/useToastStore';
 
 const useDeleteCollection = () => {
+  const { showToast } = useToastStore();
+
   const { mutate } = useMutation({
     mutationFn: (collectionId: number) => deleteCollection(collectionId),
+    onSuccess: () => showToast('success', '컬렉션이 삭제되었습니다.'),
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '컬렉션 삭제에 실패하였습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
+    },
   });
 
   return { mutate };

--- a/src/hooks/serverStateHooks/useDeleteCollectionArtwork.ts
+++ b/src/hooks/serverStateHooks/useDeleteCollectionArtwork.ts
@@ -2,14 +2,27 @@ import { useMutation } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 
 import deleteCollectionArtwork from '@/apis/collection/deleteCollectionArtwork';
+import useToastStore from '@/stores/useToastStore';
 
 const useDeleteCollectionArtwork = () => {
   const searchParams = useSearchParams();
   const collectionId = Number(searchParams.get('collectionId'));
 
+  const { showToast } = useToastStore();
+
   const { mutate } = useMutation({
     mutationFn: (postId: number) =>
       deleteCollectionArtwork({ collectionId, postId }),
+    onSuccess: () => showToast('success', '작품이 삭제되었습니다.'),
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '작품이 삭제되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
+    },
   });
 
   return { mutate };

--- a/src/hooks/serverStateHooks/useDeleteComment.ts
+++ b/src/hooks/serverStateHooks/useDeleteComment.ts
@@ -1,10 +1,24 @@
 import { useMutation } from '@tanstack/react-query';
 
+import useToastStore from '@/stores/useToastStore';
+
 import deleteArtworkComments from '../../apis/artwork/deleteArtworkComments';
 
 const useDeleteComments = () => {
+  const { showToast } = useToastStore();
+
   const { mutate } = useMutation({
     mutationFn: (commentId: number) => deleteArtworkComments(commentId),
+    onSuccess: () => showToast('success', '댓글이 삭제되었습니다.'),
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '댓글이 삭제되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
+    },
   });
 
   return { mutate };

--- a/src/hooks/serverStateHooks/useGetAllCollectionList.ts
+++ b/src/hooks/serverStateHooks/useGetAllCollectionList.ts
@@ -5,7 +5,7 @@ import { COLLECTION } from '@/constants/API';
 import { CollectionType } from '@/types/collection';
 
 const useGetAllCollectionList = () => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [COLLECTION.collectionList],
     queryFn: () => getAllCollectionList(),
   });
@@ -13,6 +13,7 @@ const useGetAllCollectionList = () => {
   return {
     collections: data ? data.collections : ([] as CollectionType[]),
     isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetArtworkComments.ts
+++ b/src/hooks/serverStateHooks/useGetArtworkComments.ts
@@ -21,6 +21,7 @@ const useGetArtworkComments = ({
     hasNextPage,
     isFetching,
     isFetchingNextPage,
+    isError,
   } = useInfiniteQuery({
     queryKey: [ARTWORK.artworkPostComments(postId)],
     queryFn: ({ pageParam = 0 }) =>
@@ -67,11 +68,12 @@ const useGetArtworkComments = ({
 
   return {
     commentData,
-    isLoading,
     hasNextPage,
     lastCommentRef,
     observerActive,
     activeObserver,
+    isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetArtworkList.ts
+++ b/src/hooks/serverStateHooks/useGetArtworkList.ts
@@ -9,7 +9,7 @@ import {
 } from '@/types';
 
 const useGetArtworkList = (params: ArtworkListParams) => {
-  const { data, isLoading, error } = useQuery<ArtworkListResponse>({
+  const { data, isLoading, isError } = useQuery<ArtworkListResponse>({
     queryKey: [ARTWORK.artworkList, params],
     queryFn: () => getArtworkList({ ...params }),
     retry: 3,
@@ -18,7 +18,7 @@ const useGetArtworkList = (params: ArtworkListParams) => {
   return {
     data: data || { data: [], page: {} as PaginationType },
     isLoading,
-    error,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetArtworkPost.ts
+++ b/src/hooks/serverStateHooks/useGetArtworkPost.ts
@@ -6,7 +6,7 @@ import getArtworkPost from '@/apis/artwork/getArtworkPost';
 import { ARTWORK } from '@/constants/API';
 
 const useGetArtworkPost = (postId: number | null) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [ARTWORK.patchArtwork(postId as number)],
     queryFn: () => getArtworkPost(postId as number),
     enabled: !!postId,
@@ -93,9 +93,10 @@ const useGetArtworkPost = (postId: number | null) => {
     socialInfo,
     detailInfo,
     artistInfo,
-    isLoading,
     existingArtwork,
     commentCount,
+    isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetCollectionArtworks.ts
+++ b/src/hooks/serverStateHooks/useGetCollectionArtworks.ts
@@ -6,7 +6,7 @@ import { PaginationType } from '@/types';
 import { CollectionArtworksParams } from '@/types/collection';
 
 const useGetCollectionArtworks = (params: CollectionArtworksParams) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [COLLECTION.collection, params],
     queryFn: () => getCollectionArtworks({ ...params }),
   });
@@ -24,6 +24,7 @@ const useGetCollectionArtworks = (params: CollectionArtworksParams) => {
     artworks: response.data,
     pageInfo: response.page,
     isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetFollowedArtists.ts
+++ b/src/hooks/serverStateHooks/useGetFollowedArtists.ts
@@ -7,7 +7,7 @@ import TokenHandler from '@/utils/tokenHandler';
 const useGetFollowedArtists = () => {
   const accessToken = TokenHandler.getAccessToken();
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [ARTWORK.followedArtists],
     queryFn: getFollowedArtists,
     enabled: !!accessToken,
@@ -16,7 +16,7 @@ const useGetFollowedArtists = () => {
   return {
     data: data ?? [],
     isLoading,
-    error,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetFollowerList.ts
+++ b/src/hooks/serverStateHooks/useGetFollowerList.ts
@@ -9,7 +9,7 @@ const useGetFollowerList = () => {
   const userIdParam = searchParams.get('userId');
   const userId = userIdParam ? Number(userIdParam) : null;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [USER.followerList(userId as number)],
     queryFn: () => getFollowerList(userId as number),
   });
@@ -17,6 +17,7 @@ const useGetFollowerList = () => {
   return {
     followerList: data?.users ?? [],
     isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetFollowingList.tsx
+++ b/src/hooks/serverStateHooks/useGetFollowingList.tsx
@@ -9,7 +9,7 @@ const useGetFollowingList = () => {
   const userIdParam = searchParams.get('userId');
   const userId = userIdParam ? Number(userIdParam) : null;
 
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [USER.followingList(userId as number)],
     queryFn: () => getFollowingList(userId as number),
     enabled: !!userId,
@@ -18,6 +18,7 @@ const useGetFollowingList = () => {
   return {
     followingList: data?.users ?? [],
     isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetLikedArtworkList.tsx
+++ b/src/hooks/serverStateHooks/useGetLikedArtworkList.tsx
@@ -8,7 +8,7 @@ interface UseGetLikedArtworkListProps
   extends Pick<ArtworkListParams, 'sort' | 'page' | 'size'> {}
 
 const useGetLikedArtworkList = (params: UseGetLikedArtworkListProps) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [USER.likedArtworkList, params],
     queryFn: () => getLikedArtworkList({ ...params }),
   });
@@ -22,6 +22,7 @@ const useGetLikedArtworkList = (params: UseGetLikedArtworkListProps) => {
     artworkList: result.data,
     pageInfo: result.page,
     isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetProfileArtworkList.tsx
+++ b/src/hooks/serverStateHooks/useGetProfileArtworkList.tsx
@@ -6,7 +6,7 @@ import { PaginationType } from '@/types';
 import { UserArtworkListParams } from '@/types/user';
 
 const useGetProfileArtworkList = (params: UserArtworkListParams) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [USER.artworkList, params],
     queryFn: () => getProfileArtworkList({ ...params }),
   });
@@ -22,6 +22,7 @@ const useGetProfileArtworkList = (params: UserArtworkListParams) => {
     artworkList: result.data,
     pageInfo: result.page,
     isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetProfileCollectionList.ts
+++ b/src/hooks/serverStateHooks/useGetProfileCollectionList.ts
@@ -6,7 +6,7 @@ import { PaginationType } from '@/types';
 import { UserArtworkListParams } from '@/types/user';
 
 const useGetProfileCollectionList = (params: UserArtworkListParams) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [COLLECTION.collectionList, params],
     queryFn: () => getProfileCollectionList({ ...params }),
   });
@@ -22,6 +22,7 @@ const useGetProfileCollectionList = (params: UserArtworkListParams) => {
     collections: response.data,
     pageInfo: response.page,
     isLoading,
+    isError,
   };
 };
 

--- a/src/hooks/serverStateHooks/useGetProfileInfo.ts
+++ b/src/hooks/serverStateHooks/useGetProfileInfo.ts
@@ -9,7 +9,7 @@ const useGetProfileInfo = (userId: number | null) => {
     queryKey: [USER.userProfile, userId],
     queryFn: () => {
       if (userId === null) {
-        throw new Error('userId is required');
+        throw new Error('userId는 필수입니다.');
       }
       return getProfileInfo(userId);
     },

--- a/src/hooks/serverStateHooks/useGetProfileInfo.ts
+++ b/src/hooks/serverStateHooks/useGetProfileInfo.ts
@@ -5,7 +5,7 @@ import { USER } from '@/constants/API';
 import { UserType } from '@/types/user';
 
 const useGetProfileInfo = (userId: number | null) => {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: [USER.userProfile, userId],
     queryFn: () => {
       if (userId === null) {
@@ -28,7 +28,7 @@ const useGetProfileInfo = (userId: number | null) => {
     enabled: !!userId,
   });
 
-  return { userInfo: data, isLoading };
+  return { userInfo: data, isLoading, isError };
 };
 
 export default useGetProfileInfo;

--- a/src/hooks/serverStateHooks/usePatchArtwork.ts
+++ b/src/hooks/serverStateHooks/usePatchArtwork.ts
@@ -19,8 +19,14 @@ const usePatchArtwork = () => {
     onSuccess: () => {
       showToast('success', '작품이 수정되었습니다.');
     },
-    onError: () => {
-      showToast('error', '작품 수정에 실패했습니다.');
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '작품 수정에 실패했습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
     },
   });
 };

--- a/src/hooks/serverStateHooks/usePatchArtwork.ts
+++ b/src/hooks/serverStateHooks/usePatchArtwork.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import patchArtwork from '@/apis/artwork/patchArtwork';
+import useToastStore from '@/stores/useToastStore';
 import { PatchArtworkData } from '@/types';
 
 interface PatchArtworkParams {
@@ -9,12 +10,17 @@ interface PatchArtworkParams {
 }
 
 const usePatchArtwork = () => {
+  const { showToast } = useToastStore();
+
   return useMutation({
     mutationFn: ({ postId, data }: PatchArtworkParams) => {
       return patchArtwork(postId, data);
     },
-    onError: (error) => {
-      console.error('작품 수정 실패: ', error);
+    onSuccess: () => {
+      showToast('success', '작품이 수정되었습니다.');
+    },
+    onError: () => {
+      showToast('error', '작품 수정에 실패했습니다.');
     },
   });
 };

--- a/src/hooks/serverStateHooks/usePatchArtworkComment.ts
+++ b/src/hooks/serverStateHooks/usePatchArtworkComment.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
-import patchArtworkComment from '@/apis/artwork/patchArtwokrComment';
+import patchArtworkComment from '@/apis/artwork/patchArtworkComment';
 
 interface MutateProps {
   content: string;

--- a/src/hooks/serverStateHooks/usePatchArtworkComment.ts
+++ b/src/hooks/serverStateHooks/usePatchArtworkComment.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import patchArtworkComment from '@/apis/artwork/patchArtworkComment';
+import useToastStore from '@/stores/useToastStore';
 
 interface MutateProps {
   content: string;
@@ -8,9 +9,21 @@ interface MutateProps {
 }
 
 const usePatchArtworkComment = () => {
+  const { showToast } = useToastStore();
+
   const { mutate } = useMutation({
     mutationFn: ({ content, commentId }: MutateProps) =>
       patchArtworkComment(commentId, content),
+    onSuccess: () => showToast('success', '댓글이 수정되었습니다.'),
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '댓글이 수정되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
+    },
   });
 
   return { mutate };

--- a/src/hooks/serverStateHooks/usePatchCollection.ts
+++ b/src/hooks/serverStateHooks/usePatchCollection.ts
@@ -1,15 +1,25 @@
 import { useMutation } from '@tanstack/react-query';
 
 import patchCollection from '@/apis/collection/patchCollection';
+import useToastStore from '@/stores/useToastStore';
 import { PatchCollectionParams } from '@/types/collection';
 
 const usePatchCollection = () => {
+  const { showToast } = useToastStore();
+
   return useMutation({
     mutationFn: ({ collectionId, data }: PatchCollectionParams) => {
       return patchCollection({ collectionId, data });
     },
+    onSuccess: () => showToast('success', '컬렉션이 수정되었습니다.'),
     onError: (error) => {
-      console.error('컬렉션 수정 실패: ', error);
+      if (error instanceof Error) {
+        if (error.message === '컬렉션이 수정되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
     },
   });
 };

--- a/src/hooks/serverStateHooks/usePatchProfileInfo.ts
+++ b/src/hooks/serverStateHooks/usePatchProfileInfo.ts
@@ -2,22 +2,28 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import updateProfileInfo from '@/apis/user/updateProfileInfo';
 import { USER } from '@/constants/API';
+import useToastStore from '@/stores/useToastStore';
 import TokenHandler from '@/utils/tokenHandler';
 
 const usePatchProfileInfo = () => {
   const queryClient = useQueryClient();
 
+  const { showToast } = useToastStore();
+
   const { mutate: updateUserProfile, isPending } = useMutation({
     mutationFn: updateProfileInfo,
-    onError: (error) => {
-      alert(`프로필 업데이트 실패: ${error.message}`);
-    },
     onSuccess: () => {
       const userId = TokenHandler.getUserIdFromToken();
 
       queryClient.invalidateQueries({
         queryKey: [USER.userProfile, userId],
       });
+
+      showToast('success', '프로필이 수정되었습니다.');
+    },
+    onError: (error) => {
+      showToast('success', '프로필이 수정되지 않았습니다.');
+      console.error(error.message);
     },
   });
 

--- a/src/hooks/serverStateHooks/usePatchProfileInfo.ts
+++ b/src/hooks/serverStateHooks/usePatchProfileInfo.ts
@@ -23,7 +23,6 @@ const usePatchProfileInfo = () => {
     },
     onError: (error) => {
       showToast('success', '프로필이 수정되지 않았습니다.');
-      console.error(error.message);
     },
   });
 

--- a/src/hooks/serverStateHooks/usePostArtwork.ts
+++ b/src/hooks/serverStateHooks/usePostArtwork.ts
@@ -15,8 +15,14 @@ const usePostArtwork = () => {
       showToast('success', '작품이 업로드되었습니다.');
       router.push(`${ROUTE.artworkDetail}?postId=${data.postId}`);
     },
-    onError: () => {
-      showToast('error', '작품 업로드에 실패했습니다. 다시 시도해 주세요.');
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '작품이 업로드되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
     },
   });
 };

--- a/src/hooks/serverStateHooks/usePostArtwork.ts
+++ b/src/hooks/serverStateHooks/usePostArtwork.ts
@@ -3,17 +3,20 @@ import { useRouter } from 'next/navigation';
 
 import postArtwork from '@/apis/artwork/postArtwork';
 import ROUTE from '@/constants/routes';
+import useToastStore from '@/stores/useToastStore';
 
 const usePostArtwork = () => {
   const router = useRouter();
+  const { showToast } = useToastStore();
 
   return useMutation({
     mutationFn: postArtwork,
-    onError: (error) => {
-      console.error('작품 업로드 중 에러 발생: ', error);
-    },
     onSuccess: (data) => {
+      showToast('success', '작품이 업로드되었습니다.');
       router.push(`${ROUTE.artworkDetail}?postId=${data.postId}`);
+    },
+    onError: () => {
+      showToast('error', '작품 업로드에 실패했습니다. 다시 시도해 주세요.');
     },
   });
 };

--- a/src/hooks/serverStateHooks/usePostCollection.tsx
+++ b/src/hooks/serverStateHooks/usePostCollection.tsx
@@ -9,17 +9,22 @@ import CollectionModal from '@/components/Modal/CollectionModal';
 import CreateCollectionModal from '@/components/Modal/CreateCollectionModal';
 import { COLLECTION } from '@/constants/API';
 import modalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/useToastStore';
 
 const usePostCollection = () => {
-  const { openModal, closeModal } = useStore(modalStore);
   const queryClient = useQueryClient();
   const isProfile = usePathname().includes('profile');
+
+  const { openModal, closeModal } = useStore(modalStore);
+  const { showToast } = useToastStore();
 
   const { mutate } = useMutation({
     mutationFn: ({ name, isPrivate }: PostCollectionProps) =>
       postCollection({ name, isPrivate }),
+
     onSuccess: () => {
       closeModal();
+      showToast('success', '컬렉션이 생성되었습니다.');
 
       openModal({
         modalSize: isProfile ? 'md' : 'lg',
@@ -30,6 +35,16 @@ const usePostCollection = () => {
         queryClient.invalidateQueries({
           queryKey: [COLLECTION.collectionList],
         });
+      }
+    },
+
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '이미 존재하는 컬렉션 이름입니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
       }
     },
   });

--- a/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
+++ b/src/hooks/serverStateHooks/usePostCollectionAddArtwork.tsx
@@ -6,10 +6,12 @@ import postCollectionAddArtwork from '@/apis/collection/postCollectionAddArtwork
 import ConfirmModal from '@/components/Modal/ConfirmModal';
 import ROUTE from '@/constants/routes';
 import modalStore from '@/stores/modalStore';
+import useToastStore from '@/stores/useToastStore';
 
 const usePostCollectionAddArtwork = () => {
   const router = useRouter();
   const { openModal, closeModal } = useStore(modalStore);
+  const { showToast } = useToastStore();
 
   const searchParams = useSearchParams();
   const artworkId = Number(searchParams.get('postId'));
@@ -17,6 +19,7 @@ const usePostCollectionAddArtwork = () => {
   const { mutate } = useMutation({
     mutationFn: (collectionId: number) =>
       postCollectionAddArtwork({ collectionId, postId: artworkId }),
+
     onSuccess: (_, variables) => {
       closeModal();
 
@@ -34,6 +37,16 @@ const usePostCollectionAddArtwork = () => {
           </ConfirmModal>
         ),
       });
+    },
+
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '작품이 컬렉션에 저장되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
     },
   });
 

--- a/src/hooks/serverStateHooks/usePostComment.ts
+++ b/src/hooks/serverStateHooks/usePostComment.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { ARTWORK } from '@/constants/API';
+import useToastStore from '@/stores/useToastStore';
 
 import postComment from '../../apis/artwork/postComment';
 
@@ -11,15 +12,27 @@ interface MutateProps {
 
 const usePostComment = (postId: number) => {
   const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
 
   const { mutate } = useMutation({
     mutationFn: ({ postId, content }: MutateProps) =>
       postComment({ postId, content }),
+
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [ARTWORK.artworkPostComments(postId)],
       });
-      alert('댓글 생성 성공');
+      showToast('success', '댓글이 작성되었습니다.');
+    },
+
+    onError: (error) => {
+      if (error instanceof Error) {
+        if (error.message === '댓글이 작성되지 않았습니다.') {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
     },
   });
 

--- a/src/hooks/serverStateHooks/useToggleFollow.ts
+++ b/src/hooks/serverStateHooks/useToggleFollow.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import deleteFollow from '@/apis/follow/deleteFollow';
 import postFollow from '@/apis/follow/postFollow';
 import { ARTWORK, USER } from '@/constants/API';
+import useToastStore from '@/stores/useToastStore';
 import TokenHandler from '@/utils/tokenHandler';
 
 const useToggleFollow = ({
@@ -12,7 +13,9 @@ const useToggleFollow = ({
   initFollowState: boolean | null;
 }) => {
   const [isFollowing, setIsFollowing] = useState(initFollowState);
+
   const queryClient = useQueryClient();
+  const { showToast } = useToastStore();
 
   useEffect(() => {
     setIsFollowing(initFollowState);
@@ -41,10 +44,20 @@ const useToggleFollow = ({
       }
 
       setIsFollowing(!following);
+      showToast('success', '팔로우 상태가 변경되었습니다.');
     },
 
     onError: (error) => {
-      console.error('팔로우 상태 변경 에러: ', error.message);
+      if (error instanceof Error) {
+        if (
+          error.message === '팔로우가 취소되지 않았습니다.' ||
+          error.message === '팔로우가 반영되지 않았습니다.'
+        ) {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
     },
   });
 

--- a/src/hooks/serverStateHooks/useToggleLike.ts
+++ b/src/hooks/serverStateHooks/useToggleLike.ts
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import deleteArtworkLike from '@/apis/artwork/deleteArtworkLike';
 import postArtworkLike from '@/apis/artwork/postArtworkLike';
+import useToastStore from '@/stores/useToastStore';
 
 interface UseToggleLikeProps {
   isLiked: boolean;
@@ -11,7 +12,10 @@ interface UseToggleLikeProps {
 
 const useToggleLike = (initialLikeStatus: UseToggleLikeProps) => {
   const [likeStatus, setLikeStatus] = useState(initialLikeStatus);
+
   const { isLiked, likeCount } = likeStatus;
+  const { showToast } = useToastStore();
+
   const { mutate } = useMutation<void, Error, number>({
     mutationFn: async (postId: number) => {
       isLiked === true
@@ -24,10 +28,20 @@ const useToggleLike = (initialLikeStatus: UseToggleLikeProps) => {
         isLiked: !isLiked,
         likeCount: isLiked ? likeCount - 1 : likeCount + 1,
       });
+      showToast('success', '좋아요 상태가 변경되었습니다.');
     },
 
     onError: (error) => {
-      console.error('팔로우 상태 변경 에러: ', error.message);
+      if (error instanceof Error) {
+        if (
+          error.message === '좋아요가 취소되지 않았습니다.' ||
+          error.message === '좋아요가 반영되지 않았습니다.'
+        ) {
+          showToast('error', error.message);
+        } else {
+          console.error(error.message);
+        }
+      }
     },
   });
 

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+type ToastMessage = {
+  id: number;
+  type: 'success' | 'error';
+  message: string;
+};
+
+type ToastStore = {
+  toasts: ToastMessage[];
+  showToast: (type: 'success' | 'error', message: string) => void;
+};
+
+const useToastStore = create<ToastStore>((set) => ({
+  toasts: [],
+
+  showToast: (type, message) => {
+    const id = Date.now();
+    set((state) => ({ toasts: [...state.toasts, { id, type, message }] }));
+
+    setTimeout(() => {
+      set((state) => ({
+        toasts: state.toasts.filter((toast) => toast.id !== id),
+      }));
+    }, 2400);
+  },
+}));
+
+export default useToastStore;

--- a/src/utils/copyClipboard.ts
+++ b/src/utils/copyClipboard.ts
@@ -5,7 +5,7 @@ const copyClipboard = async (text: string) => {
 
       return true;
     } else {
-      throw new Error('Clipboard API not available');
+      throw new Error('Clipboard API를 사용할 수 없습니다.');
     }
   } catch (e) {
     console.error(e);


### PR DESCRIPTION
## 📝 작업 내용
1. **`ToastPopup` UI 구현 및 전역 상태로 관리**
2. API 명세서에 새 Error Code 추가에 따른 Error Message 반영
3. Error Message Logging 중복 제거 (`throw`로 대체)
4. `ToastPopup`이 제거될 때의 UI 동작 수정
5. 커뮤니티 버튼 삭제
6. GitHub Actions | Label Workflow 수정 (bug → fix, feature → feat & 누락된 Label 추가)


## 📸 스크린샷 (선택)
### (1) ToastPopup UI
![ToastPopup UI Test](https://github.com/user-attachments/assets/58b8ab74-05b9-42d5-bd70-2addece2da5d)

### (2) GitHub Actions | Label Workflow 수정
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ff23be66-f853-4ad0-9602-7c1856bdd5e4" />


## 💬 전달사항
1. API 명세서의 Error Code에 따른 에러 메시지가 안 뜨는 것 같습니다. `try - catch`문에서 `isAxiosError`를 통해 에러를 잡고 `errorMessage` 상수 파일에 선언된 에러 메시지와 동일한지 비교하는 로직으로 작성하신 걸로 보입니다. 에러를 `console`로 확인해 봐도 백엔드에서 전달하는 Response의 JSON 형태로 받지 못하고 있는 듯하여 이 부분은 좀 더 확인이 필요합니다.

2. [반영 완료] `ToastPopup`이 제거될 때의 UI가 조금 덜 맘에 들어서 이 부분도 추후 수정사항 반영해서 merge 할게요 :)